### PR TITLE
cmake config exports now "include directories" of external packages for dependent projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ generate_dynamic_reconfigure_options(
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS include ${EXTERNAL_INCLUDE_DIRS}
   LIBRARIES teb_local_planner ${EXTERNAL_LIBS}
   CATKIN_DEPENDS
 	base_local_planner


### PR DESCRIPTION
export include directories of external packages as already committed in kinetic-devel branch
