### PR TITLE
Added suitesparse as dependency in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -40,6 +40,7 @@
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
+  <depend>suitesparse</depend>
   <depend>tf</depend>
   <depend>tf_conversions</depend>
   <depend>visualization_msgs</depend>


### PR DESCRIPTION
suitesparse library is not installed automatically by rosdep, when this dependency is not given in package.xml