### PR TITLE
fixed wrong matrix assignment that causes a crash of the planner

### DIFF
--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -399,7 +399,7 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
   Eigen::Matrix<double,2,2> information_inflated;
   information_inflated(0,0) = cfg_->optim.weight_obstacle * weight_multiplier;
   information_inflated(1,1) = cfg_->optim.weight_inflation;
-  information_inflated(0,1) = information(1,0) = 0;
+  information_inflated(0,1) = information_inflated(1,0) = 0;
     
   // iterate all teb points (skip first and last)
   for (int i=1; i < teb_.sizePoses()-1; ++i)


### PR DESCRIPTION
The patched fixes a bug that causes the planner to crash since it tries to access a non-existing element of the matrix _information_.
Furthermore, it seems that the original idea is to set the non-diagonal elements of the matrix _information_inflated_ to zero. 
