### PR TITLE
Adds subscriber for user-supplied via-points

### DIFF
--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -233,7 +233,12 @@ protected:
     */
   void customObstacleCB(const costmap_converter::ObstacleArrayMsg::ConstPtr& obst_msg);
   
-  
+   /**
+    * @brief Callback for custom via-points
+    * @param via_points_msg pointer to the message containing a list of via-points
+    */
+  void customViaPointsCB(const nav_msgs::Path::ConstPtr& via_points_msg);
+
    /**
     * @brief Prune global plan such that already passed poses are cut off
     * 
@@ -371,7 +376,11 @@ private:
   ros::Subscriber custom_obst_sub_; //!< Subscriber for custom obstacles received via a ObstacleMsg.
   boost::mutex custom_obst_mutex_; //!< Mutex that locks the obstacle array (multi-threaded)
   costmap_converter::ObstacleArrayMsg custom_obstacle_msg_; //!< Copy of the most recent obstacle message
-  
+
+  ros::Subscriber via_points_sub_; //!< Subscriber for custom via-points received via a Path msg.
+  bool custom_via_points_active_; //!< Keep track whether valid via-points have been received from via_points_sub_
+  boost::mutex via_point_mutex_; //!< Mutex that locks the via_points container (multi-threaded)
+
   PoseSE2 robot_pose_; //!< Store current robot pose
   PoseSE2 robot_goal_; //!< Store current robot goal
   geometry_msgs::Twist robot_vel_; //!< Store current robot translational and angular velocity (vx, vy, omega)

--- a/scripts/publish_viapoints.py
+++ b/scripts/publish_viapoints.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Author: christoph.roesmann@tu-dortmund.de
+
+import rospy, math
+from geometry_msgs.msg import PoseStamped
+from nav_msgs.msg import Path
+
+
+def publish_via_points_msg():
+  pub = rospy.Publisher('/test_optim_node/via_points', Path, queue_size=1)
+  rospy.init_node("test_via_points_msg")
+
+
+  via_points_msg = Path() 
+  via_points_msg.header.stamp = rospy.Time.now()
+  via_points_msg.header.frame_id = "odom" # CHANGE HERE: odom/map
+  
+  # Add via-points
+  point1 = PoseStamped()
+  point1.pose.position.x = 0.0;
+  point1.pose.position.y = 1.5;
+
+  point2 = PoseStamped()
+  point2.pose.position.x = 2.0;
+  point2.pose.position.y = -0.5;
+
+
+  via_points_msg.poses = [point1, point2]
+
+  r = rospy.Rate(5) # 10hz
+  t = 0.0
+  while not rospy.is_shutdown():
+        
+    pub.publish(via_points_msg)
+    
+    r.sleep()
+
+
+
+if __name__ == '__main__': 
+  try:
+    publish_via_points_msg()
+  except rospy.ROSInterruptException:
+    pass
+


### PR DESCRIPTION
This pull-requests adds the possibility to provide via-points via a topic.
Currently, the user needs to decide whether to receive via-points from the topic or to obtain them from the global reference plan (e.g., activate the latter by setting `global_plan_viapoint_sep>0` as before).

A small test script `publish_viapoints.py` is provided to demonstrate the feature within `test_optim_node`.

This PR fixes #63 .