### PR TITLE
Slightly changing the behavior of how the global plan and via-points are processed

### DIFF
--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -685,8 +685,17 @@ void TebOptimalPlanner::AddEdgesViaPoints()
       index = n-2; // set to a pose before the goal, since we can move it away!
     // check if point coincides with start or is located before it
     if ( index < 1)
-      index = 1;
-    
+    {
+      if (cfg_->trajectory.via_points_ordered)
+      {
+        index = 1; // try to connect the via point with the second (and non-fixed) pose. It is likely that autoresize adds new poses inbetween later.
+      }
+      else
+      {
+        ROS_DEBUG("TebOptimalPlanner::AddEdgesViaPoints(): skipping a via-point that is close or behind the current robot pose.");
+        continue; // skip via points really close or behind the current robot pose
+      }
+    }
     Eigen::Matrix<double,1,1> information;
     information.fill(cfg_->optim.weight_viapoint);
     

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -692,18 +692,19 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
     double sq_dist = 1e10;
     
     //we need to loop to a point on the plan that is within a certain distance of the robot
-    while(i < (int)global_plan.size())
+    for(int j=0; j < (int)global_plan.size(); ++j)
     {
-      double x_diff = robot_pose.getOrigin().x() - global_plan[i].pose.position.x;
-      double y_diff = robot_pose.getOrigin().y() - global_plan[i].pose.position.y;
+      double x_diff = robot_pose.getOrigin().x() - global_plan[j].pose.position.x;
+      double y_diff = robot_pose.getOrigin().y() - global_plan[j].pose.position.y;
       double new_sq_dist = x_diff * x_diff + y_diff * y_diff;
-      if (new_sq_dist > sq_dist && sq_dist < sq_dist_threshold) // find first distance that is greater
+      if (new_sq_dist > sq_dist_threshold)
+        break;  // force stop if we have reached the costmap border
+
+      if (new_sq_dist < sq_dist) // find closest distance
       {
         sq_dist = new_sq_dist;
-        break;
+        i = j;
       }
-      sq_dist = new_sq_dist;
-      ++i;
     }
     
     tf::Stamped<tf::Pose> tf_pose;


### PR DESCRIPTION
Global plan:
In every sampling interval, the global plan is processed in order to find the closest pose to the robot (as reference start) and the current end pose (either local at costmap boundary or `max_global_plan_lookahead_dist`). Previously, the search algorithm stopped as soon as the distance to the robot increased once. This caused troubles with more complex global plans, hence the new strategy checks the complete subset of the global plan in the local costmap for the closest distance to the robot.

This also resolves #82 

Via-Points:
In case `via_points_ordered` is turned off, every via-point that has the robot pose itself as the closest pose on the trajectory is ignored from now on.