### PR TITLE
Add omni_type option (under construction)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,32 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* This update introduces support for dynamic obstacles (thanks to Franz Albers, who implemented and tested the code).
+  Dynamic obstacle support requires parameter *include\_dynamic\_obstacles* to be activated.
+  Note, this feature is still experimental and subject to testing.
+  Motion prediction is performed using a constant velocity model.
+  Dynamic obstacles might be incorporated as follows:
+  * via a custom message provided on topic ~/obstacles (warning: we changed the message type from teb_local_planner/ObstacleMsg to costmap_converter/ObstacleArrayMsg).
+  * via the CostmapToDynamicObstacles plugin as part of the costmap\_converter package (still experimental).
+  A tutorial is going to be provided soon.
+* FeedbackMsg includes a ObstacleMsg instead of a polygon
+* ObstacleMsg removed from package since it is now part of the costmap\_converter package.
+* Homotopy class planer code update: graph search methods and equivalence classes (h-signatures) are now 
+  implemented as subclasses of more general interfaces.
+* TEB trajectory initialization now uses a max\_vel\_x argument instead of the desired time difference in order to give the optimizer a better warm start. 
+  Old methods are marked as deprecated. This change does not affect users settings.
+* Inplace rotations removed from trajectory initialization to improve convergence speed of the optimizer
+* teb\_local\_planner::ObstacleMsg removed in favor of costmap\_converter::ObstacleArrayMsg. This also requires custom obstacle publishers to update to the new format
+* the "new" trajectory resizing method is only activated, if "include_dynamic_obstacles" is set to true.
+  We introduced the non-fast mode with the support of dynamic obstacles
+  (which leads to better results in terms of x-y-t homotopy planning).
+  However, we have not yet tested this mode intensively, so we keep
+  the previous mode as default until we finish our tests.
+* added parameter and code to update costmap footprint if it is dynamic (#49)
+* Contributors: Franz Albers, Christoph Rösmann, procopiostein
+
 0.6.6 (2016-12-23)
 ------------------
 * Strategy for recovering from oscillating local plans added (see new parameters)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.2 (2018-06-08)
+------------------
 * Adds the possibility to provide via-points via a topic. 
   Currently, the user needs to decide whether to receive via-points from topic or to obtain them from the global reference plan 
   (e.g., activate the latter by setting global_plan_viapoint_sep>0 as before).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2017-09-23)
+------------------
 * This update introduces support for dynamic obstacles (thanks to Franz Albers, who implemented and tested the code).
   Dynamic obstacle support requires parameter *include\_dynamic\_obstacles* to be activated.
   Note, this feature is still experimental and subject to testing.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,28 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Parameter `switching_blocking_period` added to homotopy class planner parameter group.
+  Values greater than zero enforce the homotopy class planner to only switch to new equivalence classes as soon
+  as the given period is expired (this might reduce oscillations in some scenarios). The value is set to zero seconds
+  by default in order to not change the behavior of existing configurations.
+* Fixed unconsistent naming of parameter `global_plan_viapoint_sep`.
+  The parameter retrieved at startup was `global_plan_via_point_sep` and via dynamic_reconfigure it was `global_plan_viapoint_sep`.
+  `global_plan_via_point_sep` has now been replaced by `global_plan_viapoint_sep` since this is more consistent with the variable name
+  in the code as well as `weight_viapoint` and the ros wiki description.
+  In order to not break things, the old parameter name can still be used. However, a deprecated warning is printed.
+* transformGlobalPlan searches now for the closest point within the complete subset of the global plan in the local costmap:
+  In every sampling interval, the global plan is processed in order to find the closest pose to the robot (as reference start) 
+  and the current end pose (either local at costmap boundary or max_global_plan_lookahead_dist).
+  Previously, the search algorithm stopped as soon as the distance to the robot increased once. 
+  This caused troubles with more complex global plans, hence the new strategy checks the complete subset
+  of the global plan in the local costmap for the closest distance to the robot.
+* via-points that are very close to the current robot pose or behind the robot are now skipped (in non-ordered mode)
+* Edge creation: minor performance improvement for dynamic obstacle edges
+* dynamic_reconfigure: parameter visualize_with_time_as_z_axis_scale moved to group trajectory
+* Contributors: Christoph Rösmann
+
 0.7.2 (2018-06-08)
 ------------------
 * Adds the possibility to provide via-points via a topic. 
@@ -13,7 +35,7 @@ Changelog for package teb_local_planner
 0.7.1 (2018-06-05)
 ------------------
 * Fixed a crucial bug (from 0.6.6): A cost function for prefering a clockwise resp. anti-clockwise turn was enabled by default.
-  This cost function was only intendet to be active only for recovering from an oscillating robot. 
+  This cost function was only intended to be active only for recovering from an oscillating robot. 
   This cost led to a penalty for one of the turning directions and hence the maximum turning rate for the penalized direction could not be reached.
   Furthermore, which is more crucial: since the penalty applied only to a small (initial) subset of the trajectory, the overall control performance was poor
   (huge gap between planned motion and closed-loop trajectories led to frequent corrections of the robot pose and hence many motion reversals).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* bugfix in calculateHSignature. Fixes `#90 <https://github.com/rst-tu-dortmund/teb_local_planner/issues/90>`_.
+* fixed centroid computation in a special case of polygon-obstacles
+* Contributors: Christoph Rösmann
+
 0.8.0 (2018-08-06)
 ------------------
 * First melodic release

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,21 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fixed a crucial bug (from 0.6.6): A cost function for prefering a clockwise resp. anti-clockwise turn was enabled by default.
+  This cost function was only intendet to be active only for recovering from an oscillating robot. 
+  This cost led to a penalty for one of the turning directions and hence the maximum turning rate for the penalized direction could not be reached.
+  Furthermore, which is more crucial: since the penalty applied only to a small (initial) subset of the trajectory, the overall control performance was poor
+  (huge gap between planned motion and closed-loop trajectories led to frequent corrections of the robot pose and hence many motion traversals).
+* Adds support for circular obstacle types. This includes support for the radius field in costmap_converter::ObstacleMsg
+* rqt reconfigure: parameters are now grouped in tabs (robot, trajectory, viapoints, ...)
+* Update to use non deprecated pluginlib macro
+* Python scripts updated to new obstacle message definition.
+* Fixed issue when start and end are at the same location (PR #43)
+* Normalize marker quaternions in *test_optim_node*
+* Contributors: Christoph Rösmann, Alexander Reimann, Mikael Arguedas, wollip
+
 0.7.0 (2017-09-23)
 ------------------
 * This update introduces support for dynamic obstacles (thanks to Franz Albers, who implemented and tested the code).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.8.0 (2018-08-06)
+------------------
 * First melodic release
 * Updated to new g2o API
 * Migration to tf2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.3 (2018-07-05)
+------------------
 * Parameter `switching_blocking_period` added to homotopy class planner parameter group.
   Values greater than zero enforce the homotopy class planner to only switch to new equivalence classes as soon
   as the given period is expired (this might reduce oscillations in some scenarios). The value is set to zero seconds

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.1 (2018-06-05)
+------------------
 * Fixed a crucial bug (from 0.6.6): A cost function for prefering a clockwise resp. anti-clockwise turn was enabled by default.
   This cost function was only intendet to be active only for recovering from an oscillating robot. 
   This cost led to a penalty for one of the turning directions and hence the maximum turning rate for the penalized direction could not be reached.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Adds the possibility to provide via-points via a topic. 
+  Currently, the user needs to decide whether to receive via-points from topic or to obtain them from the global reference plan 
+  (e.g., activate the latter by setting global_plan_viapoint_sep>0 as before).
+  A small test script publish_viapoints.py is provided to demonstrate the feature within test_optim_node.
+* Contributors: Christoph Rösmann
+
 0.7.1 (2018-06-05)
 ------------------
 * Fixed a crucial bug (from 0.6.6): A cost function for prefering a clockwise resp. anti-clockwise turn was enabled by default.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* First melodic release
+* Updated to new g2o API
+* Migration to tf2
+* Contributors: Christoph Rösmann
+
 0.7.3 (2018-07-05)
 ------------------
 * Parameter `switching_blocking_period` added to homotopy class planner parameter group.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package teb_local_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.8.1 (2018-08-14)
+------------------
 * bugfix in calculateHSignature. Fixes `#90 <https://github.com/rst-tu-dortmund/teb_local_planner/issues/90>`_.
 * fixed centroid computation in a special case of polygon-obstacles
 * Contributors: Christoph Rösmann

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,10 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
   pluginlib
-  tf
-  tf_conversions
+  tf2
+  tf2_eigen
+  tf2_geometry_msgs
+  tf2_ros
   visualization_msgs
 )
 message(STATUS "System: ${CMAKE_SYSTEM}")
@@ -156,8 +158,8 @@ catkin_package(
 	pluginlib
 	roscpp
 	std_msgs
-	tf
-	tf_conversions
+        tf2
+        tf2_ros
 	visualization_msgs
   DEPENDS SUITESPARSE G2O
 )

--- a/include/teb_local_planner/g2o_types/edge_acceleration.h
+++ b/include/teb_local_planner/g2o_types/edge_acceleration.h
@@ -32,7 +32,7 @@
  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * Notes:
  * The following class is derived from a class defined by the
  * g2o-framework. g2o is licensed under the terms of the BSD License.
@@ -60,11 +60,11 @@ namespace teb_local_planner
 /**
  * @class EdgeAcceleration
  * @brief Edge defining the cost function for limiting the translational and rotational acceleration.
- * 
+ *
  * The edge depends on five vertices \f$ \mathbf{s}_i, \mathbf{s}_{ip1}, \mathbf{s}_{ip2}, \Delta T_i, \Delta T_{ip1} \f$ and minimizes:
  * \f$ \min \textrm{penaltyInterval}( [a, omegadot } ]^T ) \cdot weight \f$. \n
  * \e a is calculated using the difference quotient (twice) and the position parts of all three poses \n
- * \e omegadot is calculated using the difference quotient of the yaw angles followed by a normalization to [-pi, pi]. \n 
+ * \e omegadot is calculated using the difference quotient of the yaw angles followed by a normalization to [-pi, pi]. \n
  * \e weight can be set using setInformation() \n
  * \e penaltyInterval denotes the penalty function, see penaltyBoundToInterval() \n
  * The dimension of the error / cost vector is 2: the first component represents the translational acceleration and
@@ -74,22 +74,22 @@ namespace teb_local_planner
  * @see EdgeAccelerationGoal
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationStart() and EdgeAccelerationGoal() for defining boundary values!
- */    
+ */
 class EdgeAcceleration : public BaseTebMultiEdge<2, double>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */ 
+   */
   EdgeAcceleration()
   {
     this->resize(5);
   }
-    
+
   /**
    * @brief Actual cost function
-   */   
+   */
   void computeError()
   {
     ROS_ASSERT_MSG(cfg_, "You must call setTebConfig on EdgeAcceleration()");
@@ -102,12 +102,12 @@ public:
     // VELOCITY & ACCELERATION
     const Eigen::Vector2d diff1 = pose2->position() - pose1->position();
     const Eigen::Vector2d diff2 = pose3->position() - pose2->position();
-        
+
     double dist1 = diff1.norm();
     double dist2 = diff2.norm();
     const double angle_diff1 = g2o::normalize_theta(pose2->theta() - pose1->theta());
     const double angle_diff2 = g2o::normalize_theta(pose3->theta() - pose2->theta());
-    
+
     if (cfg_->trajectory.exact_arc_length) // use exact arc length instead of Euclidean approximation
     {
         if (angle_diff1 != 0)
@@ -121,30 +121,30 @@ public:
             dist2 = fabs( angle_diff2 * radius ); // actual arg length!
         }
     }
-    
+
     double vel1 = dist1 / dt1->dt();
     double vel2 = dist2 / dt2->dt();
-    
-    
+
+
     // consider directions
-//     vel1 *= g2o::sign(diff1[0]*cos(pose1->theta()) + diff1[1]*sin(pose1->theta())); 
-//     vel2 *= g2o::sign(diff2[0]*cos(pose2->theta()) + diff2[1]*sin(pose2->theta())); 
-    vel1 *= fast_sigmoid( 100*(diff1.x()*cos(pose1->theta()) + diff1.y()*sin(pose1->theta())) ); 
-    vel2 *= fast_sigmoid( 100*(diff2.x()*cos(pose2->theta()) + diff2.y()*sin(pose2->theta())) ); 
-    
+//     vel1 *= g2o::sign(diff1[0]*cos(pose1->theta()) + diff1[1]*sin(pose1->theta()));
+//     vel2 *= g2o::sign(diff2[0]*cos(pose2->theta()) + diff2[1]*sin(pose2->theta()));
+    vel1 *= fast_sigmoid( 100*(diff1.x()*cos(pose1->theta()) + diff1.y()*sin(pose1->theta())) );
+    vel2 *= fast_sigmoid( 100*(diff2.x()*cos(pose2->theta()) + diff2.y()*sin(pose2->theta())) );
+
     const double acc_lin  = (vel2 - vel1)*2 / ( dt1->dt() + dt2->dt() );
-   
+
 
     _error[0] = penaltyBoundToInterval(acc_lin,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     const double omega1 = angle_diff1 / dt1->dt();
     const double omega2 = angle_diff2 / dt2->dt();
     const double acc_rot  = (omega2 - omega1)*2 / ( dt1->dt() + dt2->dt() );
-      
+
     _error[1] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
-    
+
     ROS_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAcceleration::computeError() translational: _error[0]=%f\n",_error[0]);
     ROS_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAcceleration::computeError() rotational: _error[1]=%f\n",_error[1]);
   }
@@ -172,7 +172,7 @@ public:
     Eigen::Vector2d deltaS2 = conf3->estimate() - conf2->estimate();
     double dist1 = deltaS1.norm();
     double dist2 = deltaS2.norm();
-    
+
     double sum_time = deltaT1->estimate() + deltaT2->estimate();
     double sum_time_inv = 1 / sum_time;
     double dt1_inv = 1/deltaT1->estimate();
@@ -189,10 +189,10 @@ public:
     double omegadot = (omega2 - omega1) * aux0;
     double aux3 = -acc/2;
     double aux4 = -omegadot/2;
-    
+
     double dev_border_acc = penaltyBoundToIntervalDerivative(acc, tebConfig.robot_acceleration_max_trans,optimizationConfig.optimization_boundaries_epsilon,optimizationConfig.optimization_boundaries_scale,optimizationConfig.optimization_boundaries_order);
     double dev_border_omegadot = penaltyBoundToIntervalDerivative(omegadot, tebConfig.robot_acceleration_max_rot,optimizationConfig.optimization_boundaries_epsilon,optimizationConfig.optimization_boundaries_scale,optimizationConfig.optimization_boundaries_order);
-    
+
     _jacobianOplus[0].resize(2,2); // conf1
     _jacobianOplus[1].resize(2,2); // conf2
     _jacobianOplus[2].resize(2,2); // conf3
@@ -201,10 +201,10 @@ public:
     _jacobianOplus[5].resize(2,1); // angle1
     _jacobianOplus[6].resize(2,1); // angle2
     _jacobianOplus[7].resize(2,1); // angle3
-    
+
     if (aux1==0) aux1=1e-20;
     if (aux2==0) aux2=1e-20;
-  
+
     if (dev_border_acc!=0)
     {
       // TODO: double aux = aux0 * dev_border_acc;
@@ -231,7 +231,7 @@ public:
       _jacobianOplus[3](0,0) = 0; // acc deltaT1
       _jacobianOplus[4](0,0) = 0; // acc deltaT2
     }
-    
+
     if (dev_border_omegadot!=0)
     {
       _jacobianOplus[3](1,0) = aux0 * ( aux4 + omega1 * dt1_inv ) * dev_border_omegadot; // omegadot deltaT1
@@ -262,13 +262,13 @@ public:
 #endif
 #endif
 
-      
-public: 
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-   
+
 };
-    
-    
+
+
 /**
  * @class EdgeAccelerationStart
  * @brief Edge defining the cost function for limiting the translational and rotational acceleration at the beginning of the trajectory.
@@ -287,24 +287,24 @@ public:
  * @see EdgeAccelerationGoal
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationGoal() for defining boundary values at the end of the trajectory!
- */      
+ */
 class EdgeAccelerationStart : public BaseTebMultiEdge<2, const geometry_msgs::Twist*>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */	  
+   */	
   EdgeAccelerationStart()
   {
     _measurement = NULL;
     this->resize(3);
   }
-  
-  
+
+
   /**
    * @brief Actual cost function
-   */   
+   */
   void computeError()
   {
     ROS_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setStartVelocity() on EdgeAccelerationStart()");
@@ -321,49 +321,49 @@ public:
         const double radius =  dist/(2*sin(angle_diff/2));
         dist = fabs( angle_diff * radius ); // actual arg length!
     }
-    
+
     const double vel1 = _measurement->linear.x;
     double vel2 = dist / dt->dt();
 
     // consider directions
-    //vel2 *= g2o::sign(diff[0]*cos(pose1->theta()) + diff[1]*sin(pose1->theta())); 
-    vel2 *= fast_sigmoid( 100*(diff.x()*cos(pose1->theta()) + diff.y()*sin(pose1->theta())) ); 
-    
+    //vel2 *= g2o::sign(diff[0]*cos(pose1->theta()) + diff[1]*sin(pose1->theta()));
+    vel2 *= fast_sigmoid( 100*(diff.x()*cos(pose1->theta()) + diff.y()*sin(pose1->theta())) );
+
     const double acc_lin  = (vel2 - vel1) / dt->dt();
-    
+
     _error[0] = penaltyBoundToInterval(acc_lin,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     const double omega1 = _measurement->angular.z;
     const double omega2 = angle_diff / dt->dt();
     const double acc_rot  = (omega2 - omega1) / dt->dt();
-      
+
     _error[1] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
     ROS_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAccelerationStart::computeError() translational: _error[0]=%f\n",_error[0]);
     ROS_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAccelerationStart::computeError() rotational: _error[1]=%f\n",_error[1]);
   }
-  
+
   /**
    * @brief Set the initial velocity that is taken into account for calculating the acceleration
    * @param vel_start twist message containing the translational and rotational velocity
-   */    
+   */
   void setInitialVelocity(const geometry_msgs::Twist& vel_start)
   {
     _measurement = &vel_start;
   }
-  
-public:       
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-};    
-    
-    
-    
+};
+
+
+
 
 /**
  * @class EdgeAccelerationGoal
  * @brief Edge defining the cost function for limiting the translational and rotational acceleration at the end of the trajectory.
- * 
+ *
  * The edge depends on three vertices \f$ \mathbf{s}_i, \mathbf{s}_{ip1}, \Delta T_i \f$, an initial velocity defined by setGoalVelocity()
  * and minimizes: \n
  * \f$ \min \textrm{penaltyInterval}( [a, omegadot ]^T ) \cdot weight \f$. \n
@@ -378,24 +378,24 @@ public:
  * @see EdgeAccelerationStart
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationStart() for defining boundary (initial) values at the end of the trajectory
- */  
+ */
 class EdgeAccelerationGoal : public BaseTebMultiEdge<2, const geometry_msgs::Twist*>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */  
+   */
   EdgeAccelerationGoal()
   {
     _measurement = NULL;
     this->resize(3);
   }
-  
+
 
   /**
    * @brief Actual cost function
-   */ 
+   */
   void computeError()
   {
     ROS_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setGoalVelocity() on EdgeAccelerationGoal()");
@@ -405,7 +405,7 @@ public:
 
     // VELOCITY & ACCELERATION
 
-    const Eigen::Vector2d diff = pose_goal->position() - pose_pre_goal->position();  
+    const Eigen::Vector2d diff = pose_goal->position() - pose_pre_goal->position();
     double dist = diff.norm();
     const double angle_diff = g2o::normalize_theta(pose_goal->theta() - pose_pre_goal->theta());
     if (cfg_->trajectory.exact_arc_length  && angle_diff != 0)
@@ -413,79 +413,79 @@ public:
         double radius =  dist/(2*sin(angle_diff/2));
         dist = fabs( angle_diff * radius ); // actual arg length!
     }
-    
+
     double vel1 = dist / dt->dt();
     const double vel2 = _measurement->linear.x;
-    
+
     // consider directions
-    //vel1 *= g2o::sign(diff[0]*cos(pose_pre_goal->theta()) + diff[1]*sin(pose_pre_goal->theta())); 
-    vel1 *= fast_sigmoid( 100*(diff.x()*cos(pose_pre_goal->theta()) + diff.y()*sin(pose_pre_goal->theta())) ); 
-    
+    //vel1 *= g2o::sign(diff[0]*cos(pose_pre_goal->theta()) + diff[1]*sin(pose_pre_goal->theta()));
+    vel1 *= fast_sigmoid( 100*(diff.x()*cos(pose_pre_goal->theta()) + diff.y()*sin(pose_pre_goal->theta())) );
+
     const double acc_lin  = (vel2 - vel1) / dt->dt();
 
     _error[0] = penaltyBoundToInterval(acc_lin,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     const double omega1 = angle_diff / dt->dt();
     const double omega2 = _measurement->angular.z;
     const double acc_rot  = (omega2 - omega1) / dt->dt();
-      
+
     _error[1] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
     ROS_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAccelerationGoal::computeError() translational: _error[0]=%f\n",_error[0]);
     ROS_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAccelerationGoal::computeError() rotational: _error[1]=%f\n",_error[1]);
   }
-    
+
   /**
    * @brief Set the goal / final velocity that is taken into account for calculating the acceleration
    * @param vel_goal twist message containing the translational and rotational velocity
-   */    
+   */
   void setGoalVelocity(const geometry_msgs::Twist& vel_goal)
   {
     _measurement = &vel_goal;
   }
-  
-public: 
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-}; 
-    
+};
+
 
 
 
 /**
  * @class EdgeAccelerationHolonomic
  * @brief Edge defining the cost function for limiting the translational and rotational acceleration.
- * 
+ *
  * The edge depends on five vertices \f$ \mathbf{s}_i, \mathbf{s}_{ip1}, \mathbf{s}_{ip2}, \Delta T_i, \Delta T_{ip1} \f$ and minimizes:
  * \f$ \min \textrm{penaltyInterval}( [ax, ay, omegadot } ]^T ) \cdot weight \f$. \n
  * \e ax is calculated using the difference quotient (twice) and the x position parts of all three poses \n
  * \e ay is calculated using the difference quotient (twice) and the y position parts of all three poses \n
- * \e omegadot is calculated using the difference quotient of the yaw angles followed by a normalization to [-pi, pi]. \n 
+ * \e omegadot is calculated using the difference quotient of the yaw angles followed by a normalization to [-pi, pi]. \n
  * \e weight can be set using setInformation() \n
  * \e penaltyInterval denotes the penalty function, see penaltyBoundToInterval() \n
- * The dimension of the error / cost vector is 3: the first component represents the translational acceleration (x-dir), 
+ * The dimension of the error / cost vector is 3: the first component represents the translational acceleration (x-dir),
  * the second one the strafing acceleration and the third one the rotational acceleration.
  * @see TebOptimalPlanner::AddEdgesAcceleration
  * @see EdgeAccelerationHolonomicStart
  * @see EdgeAccelerationHolonomicGoal
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationHolonomicStart() and EdgeAccelerationHolonomicGoal() for defining boundary values!
- */    
+ */
 class EdgeAccelerationHolonomic : public BaseTebMultiEdge<3, double>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */    
+   */
   EdgeAccelerationHolonomic()
   {
     this->resize(5);
   }
-    
+
   /**
    * @brief Actual cost function
-   */   
+   */
   void computeError()
   {
     ROS_ASSERT_MSG(cfg_, "You must call setTebConfig on EdgeAcceleration()");
@@ -498,48 +498,48 @@ public:
     // VELOCITY & ACCELERATION
     Eigen::Vector2d diff1 = pose2->position() - pose1->position();
     Eigen::Vector2d diff2 = pose3->position() - pose2->position();
-    
+
     double cos_theta1 = std::cos(pose1->theta());
-    double sin_theta1 = std::sin(pose1->theta()); 
+    double sin_theta1 = std::sin(pose1->theta());
     double cos_theta2 = std::cos(pose2->theta());
-    double sin_theta2 = std::sin(pose2->theta()); 
-    
+    double sin_theta2 = std::sin(pose2->theta());
+
     // transform pose2 into robot frame pose1 (inverse 2d rotation matrix)
     double p1_dx =  cos_theta1*diff1.x() + sin_theta1*diff1.y();
     double p1_dy = -sin_theta1*diff1.x() + cos_theta1*diff1.y();
     // transform pose3 into robot frame pose2 (inverse 2d rotation matrix)
     double p2_dx =  cos_theta2*diff2.x() + sin_theta2*diff2.y();
     double p2_dy = -sin_theta2*diff2.x() + cos_theta2*diff2.y();
-    
+
     double vel1_x = p1_dx / dt1->dt();
     double vel1_y = p1_dy / dt1->dt();
     double vel2_x = p2_dx / dt2->dt();
     double vel2_y = p2_dy / dt2->dt();
-    
+
     double dt12 = dt1->dt() + dt2->dt();
-    
+
     double acc_x  = (vel2_x - vel1_x)*2 / dt12;
     double acc_y  = (vel2_y - vel1_y)*2 / dt12;
-   
+
     _error[0] = penaltyBoundToInterval(acc_x,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(acc_y,cfg_->robot.acc_lim_y,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     double omega1 = g2o::normalize_theta(pose2->theta() - pose1->theta()) / dt1->dt();
     double omega2 = g2o::normalize_theta(pose3->theta() - pose2->theta()) / dt2->dt();
     double acc_rot  = (omega2 - omega1)*2 / dt12;
-      
+
     _error[2] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
-    
+
     ROS_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAcceleration::computeError() translational: _error[0]=%f\n",_error[0]);
     ROS_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAcceleration::computeError() strafing: _error[1]=%f\n",_error[1]);
     ROS_ASSERT_MSG(std::isfinite(_error[2]), "EdgeAcceleration::computeError() rotational: _error[2]=%f\n",_error[2]);
   }
 
-public: 
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-   
+
 };
 
 
@@ -562,23 +562,23 @@ public:
  * @see EdgeAccelerationHolonomicGoal
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationHolonomicGoal() for defining boundary values at the end of the trajectory!
- */      
+ */
 class EdgeAccelerationHolonomicStart : public BaseTebMultiEdge<3, const geometry_msgs::Twist*>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */   
+   */
   EdgeAccelerationHolonomicStart()
   {
     this->resize(3);
     _measurement = NULL;
   }
-    
+
   /**
    * @brief Actual cost function
-   */   
+   */
   void computeError()
   {
     ROS_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setStartVelocity() on EdgeAccelerationStart()");
@@ -588,14 +588,14 @@ public:
 
     // VELOCITY & ACCELERATION
     Eigen::Vector2d diff = pose2->position() - pose1->position();
-            
+
     double cos_theta1 = std::cos(pose1->theta());
-    double sin_theta1 = std::sin(pose1->theta()); 
-    
+    double sin_theta1 = std::sin(pose1->theta());
+
     // transform pose2 into robot frame pose1 (inverse 2d rotation matrix)
     double p1_dx =  cos_theta1*diff.x() + sin_theta1*diff.y();
     double p1_dy = -sin_theta1*diff.x() + cos_theta1*diff.y();
-    
+
     double vel1_x = _measurement->linear.x;
     double vel1_y = _measurement->linear.y;
     double vel2_x = p1_dx / dt->dt();
@@ -603,41 +603,41 @@ public:
 
     double acc_lin_x  = (vel2_x - vel1_x) / dt->dt();
     double acc_lin_y  = (vel2_y - vel1_y) / dt->dt();
-    
+
     _error[0] = penaltyBoundToInterval(acc_lin_x,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(acc_lin_y,cfg_->robot.acc_lim_y,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     double omega1 = _measurement->angular.z;
     double omega2 = g2o::normalize_theta(pose2->theta() - pose1->theta()) / dt->dt();
     double acc_rot  = (omega2 - omega1) / dt->dt();
-      
+
     _error[2] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
     ROS_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAccelerationStart::computeError() translational: _error[0]=%f\n",_error[0]);
     ROS_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAccelerationStart::computeError() strafing: _error[1]=%f\n",_error[1]);
     ROS_ASSERT_MSG(std::isfinite(_error[2]), "EdgeAccelerationStart::computeError() rotational: _error[2]=%f\n",_error[2]);
   }
-  
+
   /**
    * @brief Set the initial velocity that is taken into account for calculating the acceleration
    * @param vel_start twist message containing the translational and rotational velocity
-   */    
+   */
   void setInitialVelocity(const geometry_msgs::Twist& vel_start)
   {
     _measurement = &vel_start;
   }
-        
-public:       
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-};    
-    
-       
+};
+
+
 
 /**
  * @class EdgeAccelerationHolonomicGoal
  * @brief Edge defining the cost function for limiting the translational and rotational acceleration at the end of the trajectory.
- * 
+ *
  * The edge depends on three vertices \f$ \mathbf{s}_i, \mathbf{s}_{ip1}, \Delta T_i \f$, an initial velocity defined by setGoalVelocity()
  * and minimizes: \n
  * \f$ \min \textrm{penaltyInterval}( [ax, ay, omegadot ]^T ) \cdot weight \f$. \n
@@ -653,23 +653,23 @@ public:
  * @see EdgeAccelerationHolonomicStart
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationHolonomicStart() for defining boundary (initial) values at the end of the trajectory
- */  
+ */
 class EdgeAccelerationHolonomicGoal : public BaseTebMultiEdge<3, const geometry_msgs::Twist*>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */  
+   */
   EdgeAccelerationHolonomicGoal()
   {
     _measurement = NULL;
     this->resize(3);
   }
-  
+
   /**
    * @brief Actual cost function
-   */ 
+   */
   void computeError()
   {
     ROS_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setGoalVelocity() on EdgeAccelerationGoal()");
@@ -679,53 +679,53 @@ public:
 
     // VELOCITY & ACCELERATION
 
-    Eigen::Vector2d diff = pose_goal->position() - pose_pre_goal->position();    
-    
+    Eigen::Vector2d diff = pose_goal->position() - pose_pre_goal->position();
+
     double cos_theta1 = std::cos(pose_pre_goal->theta());
-    double sin_theta1 = std::sin(pose_pre_goal->theta()); 
-    
+    double sin_theta1 = std::sin(pose_pre_goal->theta());
+
     // transform pose2 into robot frame pose1 (inverse 2d rotation matrix)
     double p1_dx =  cos_theta1*diff.x() + sin_theta1*diff.y();
     double p1_dy = -sin_theta1*diff.x() + cos_theta1*diff.y();
-   
+
     double vel1_x = p1_dx / dt->dt();
     double vel1_y = p1_dy / dt->dt();
     double vel2_x = _measurement->linear.x;
     double vel2_y = _measurement->linear.y;
-    
+
     double acc_lin_x  = (vel2_x - vel1_x) / dt->dt();
     double acc_lin_y  = (vel2_y - vel1_y) / dt->dt();
 
     _error[0] = penaltyBoundToInterval(acc_lin_x,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(acc_lin_y,cfg_->robot.acc_lim_y,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     double omega1 = g2o::normalize_theta(pose_goal->theta() - pose_pre_goal->theta()) / dt->dt();
     double omega2 = _measurement->angular.z;
     double acc_rot  = (omega2 - omega1) / dt->dt();
-      
+
     _error[2] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
     ROS_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAccelerationGoal::computeError() translational: _error[0]=%f\n",_error[0]);
     ROS_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAccelerationGoal::computeError() strafing: _error[1]=%f\n",_error[1]);
     ROS_ASSERT_MSG(std::isfinite(_error[2]), "EdgeAccelerationGoal::computeError() rotational: _error[2]=%f\n",_error[2]);
   }
-  
-  
+
+
   /**
    * @brief Set the goal / final velocity that is taken into account for calculating the acceleration
    * @param vel_goal twist message containing the translational and rotational velocity
-   */    
+   */
   void setGoalVelocity(const geometry_msgs::Twist& vel_goal)
   {
     _measurement = &vel_goal;
   }
-  
 
-public: 
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-}; 
-    
+};
+
 
 
 

--- a/include/teb_local_planner/g2o_types/edge_velocity.h
+++ b/include/teb_local_planner/g2o_types/edge_velocity.h
@@ -32,7 +32,7 @@
  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * Notes:
  * The following class is derived from a class defined by the
  * g2o-framework. g2o is licensed under the terms of the BSD License.
@@ -56,11 +56,11 @@
 namespace teb_local_planner
 {
 
-  
+
 /**
  * @class EdgeVelocity
  * @brief Edge defining the cost function for limiting the translational and rotational velocity.
- * 
+ *
  * The edge depends on three vertices \f$ \mathbf{s}_i, \mathbf{s}_{ip1}, \Delta T_i \f$ and minimizes: \n
  * \f$ \min \textrm{penaltyInterval}( [v,omega]^T ) \cdot weight \f$. \n
  * \e v is calculated using the difference quotient and the position parts of both poses. \n
@@ -71,31 +71,31 @@ namespace teb_local_planner
  * the second one the rotational velocity.
  * @see TebOptimalPlanner::AddEdgesVelocity
  * @remarks Do not forget to call setTebConfig()
- */  
+ */
 class EdgeVelocity : public BaseTebMultiEdge<2, double>
 {
 public:
-  
+
   /**
    * @brief Construct edge.
-   */	      
+   */	
   EdgeVelocity()
   {
     this->resize(3); // Since we derive from a g2o::BaseMultiEdge, set the desired number of vertices
   }
-  
+
   /**
    * @brief Actual cost function
-   */  
+   */
   void computeError()
   {
     ROS_ASSERT_MSG(cfg_, "You must call setTebConfig on EdgeVelocity()");
     const VertexPose* conf1 = static_cast<const VertexPose*>(_vertices[0]);
     const VertexPose* conf2 = static_cast<const VertexPose*>(_vertices[1]);
     const VertexTimeDiff* deltaT = static_cast<const VertexTimeDiff*>(_vertices[2]);
-    
+
     const Eigen::Vector2d deltaS = conf2->estimate().position() - conf1->estimate().position();
-    
+
     double dist = deltaS.norm();
     const double angle_diff = g2o::normalize_theta(conf2->theta() - conf1->theta());
     if (cfg_->trajectory.exact_arc_length && angle_diff != 0)
@@ -104,12 +104,12 @@ public:
         dist = fabs( angle_diff * radius ); // actual arg length!
     }
     double vel = dist / deltaT->estimate();
-    
+
 //     vel *= g2o::sign(deltaS[0]*cos(conf1->theta()) + deltaS[1]*sin(conf1->theta())); // consider direction
     vel *= fast_sigmoid( 100 * (deltaS.x()*cos(conf1->theta()) + deltaS.y()*sin(conf1->theta())) ); // consider direction
-    
+
     const double omega = angle_diff / deltaT->estimate();
-  
+
     _error[0] = penaltyBoundToInterval(vel, -cfg_->robot.max_vel_x_backwards, cfg_->robot.max_vel_x,cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(omega, cfg_->robot.max_vel_theta,cfg_->optim.penalty_epsilon);
 
@@ -129,25 +129,25 @@ public:
     const VertexPose* conf1 = static_cast<const VertexPose*>(_vertices[0]);
     const VertexPose* conf2 = static_cast<const VertexPose*>(_vertices[1]);
     const VertexTimeDiff* deltaT = static_cast<const VertexTimeDiff*>(_vertices[2]);
-    
+
     Eigen::Vector2d deltaS = conf2->position() - conf1->position();
     double dist = deltaS.norm();
     double aux1 = dist*deltaT->estimate();
     double aux2 = 1/deltaT->estimate();
-    
+
     double vel = dist * aux2;
     double omega = g2o::normalize_theta(conf2->theta() - conf1->theta()) * aux2;
-    
+
     double dev_border_vel = penaltyBoundToIntervalDerivative(vel, -cfg_->robot.max_vel_x_backwards, cfg_->robot.max_vel_x,cfg_->optim.penalty_epsilon);
     double dev_border_omega = penaltyBoundToIntervalDerivative(omega, cfg_->robot.max_vel_theta,cfg_->optim.penalty_epsilon);
-    
+
     _jacobianOplus[0].resize(2,3); // conf1
     _jacobianOplus[1].resize(2,3); // conf2
     _jacobianOplus[2].resize(2,1); // deltaT
-    
+
 //  if (aux1==0) aux1=1e-6;
 //  if (aux2==0) aux2=1e-6;
-    
+
     if (dev_border_vel!=0)
     {
       double aux3 = dev_border_vel / aux1;
@@ -165,7 +165,7 @@ public:
       _jacobianOplus[1](0,1) = 0; // vel y2	
       _jacobianOplus[2](0,0) = 0; // vel deltaT
     }
-    
+
     if (dev_border_omega!=0)
     {
       double aux4 = aux2 * dev_border_omega;
@@ -189,10 +189,10 @@ public:
   }
 #endif
 #endif
- 
-  
+
+
 public:
-  
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };
@@ -205,7 +205,7 @@ public:
 /**
  * @class EdgeVelocityHolonomic
  * @brief Edge defining the cost function for limiting the translational and rotational velocity according to x,y and theta.
- * 
+ *
  * The edge depends on three vertices \f$ \mathbf{s}_i, \mathbf{s}_{ip1}, \Delta T_i \f$ and minimizes: \n
  * \f$ \min \textrm{penaltyInterval}( [vx,vy,omega]^T ) \cdot weight \f$. \n
  * \e vx denotes the translational velocity w.r.t. x-axis (computed using finite differneces). \n
@@ -217,22 +217,22 @@ public:
  * the second one w.r.t. the y-axis and the third one the rotational velocity.
  * @see TebOptimalPlanner::AddEdgesVelocity
  * @remarks Do not forget to call setTebConfig()
- */  
+ */
 class EdgeVelocityHolonomic : public BaseTebMultiEdge<3, double>
 {
 public:
-  
+
   /**
    * @brief Construct edge.
-   */       
+   */
   EdgeVelocityHolonomic()
   {
     this->resize(3); // Since we derive from a g2o::BaseMultiEdge, set the desired number of vertices
   }
-  
+
   /**
    * @brief Actual cost function
-   */  
+   */
   void computeError()
   {
     ROS_ASSERT_MSG(cfg_, "You must call setTebConfig on EdgeVelocityHolonomic()");
@@ -240,18 +240,18 @@ public:
     const VertexPose* conf2 = static_cast<const VertexPose*>(_vertices[1]);
     const VertexTimeDiff* deltaT = static_cast<const VertexTimeDiff*>(_vertices[2]);
     Eigen::Vector2d deltaS = conf2->position() - conf1->position();
-    
+
     double cos_theta1 = std::cos(conf1->theta());
-    double sin_theta1 = std::sin(conf1->theta()); 
-    
+    double sin_theta1 = std::sin(conf1->theta());
+
     // transform conf2 into current robot frame conf1 (inverse 2d rotation matrix)
     double r_dx =  cos_theta1*deltaS.x() + sin_theta1*deltaS.y();
     double r_dy = -sin_theta1*deltaS.x() + cos_theta1*deltaS.y();
-    
+
     double vx = r_dx / deltaT->estimate();
     double vy = r_dy / deltaT->estimate();
     double omega = g2o::normalize_theta(conf2->theta() - conf1->theta()) / deltaT->estimate();
-    
+
     _error[0] = penaltyBoundToInterval(vx, -cfg_->robot.max_vel_x_backwards, cfg_->robot.max_vel_x, cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(vy, cfg_->robot.max_vel_y, 0.0); // we do not apply the penalty epsilon here, since the velocity could be close to zero
     _error[2] = penaltyBoundToInterval(omega, cfg_->robot.max_vel_theta,cfg_->optim.penalty_epsilon);
@@ -259,10 +259,10 @@ public:
     ROS_ASSERT_MSG(std::isfinite(_error[0]) && std::isfinite(_error[1]) && std::isfinite(_error[2]),
                    "EdgeVelocityHolonomic::computeError() _error[0]=%f _error[1]=%f _error[2]=%f\n",_error[0],_error[1],_error[2]);
   }
- 
-  
+
+
 public:
-  
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };

--- a/include/teb_local_planner/h_signature.h
+++ b/include/teb_local_planner/h_signature.h
@@ -155,21 +155,21 @@ public:
                 cplx Al = f0;
                 for (std::size_t j=0; j<obstacles->size(); ++j)
                 {
-                if (j==l)
-                    continue;
-                cplx obst_j = obstacles->at(j)->getCentroidCplx();
-                cplx diff = obst_l - obst_j;
-                //if (diff.real()!=0 || diff.imag()!=0)
-                if (std::abs(diff)<0.05) // skip really close obstacles
-                    Al /= diff;
-                else
-                    continue;
+                    if (j==l)
+                        continue;
+                    cplx obst_j = obstacles->at(j)->getCentroidCplx();
+                    cplx diff = obst_l - obst_j;
+                    //if (diff.real()!=0 || diff.imag()!=0)
+                    if (std::abs(diff)<0.05) // skip really close obstacles
+                        continue;
+                     else
+                        Al /= diff;
                 }
                 // compute log value
                 double diff2 = std::abs(z2-obst_l);
                 double diff1 = std::abs(z1-obst_l);
                 if (diff2 == 0 || diff1 == 0)
-                continue;
+                    continue;
                 double log_real = std::log(diff2)-std::log(diff1);
                 // complex ln has more than one solution -> choose minimum abs angle -> paper
                 double arg_diff = std::arg(z2-obst_l)-std::arg(z1-obst_l);

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -51,13 +51,13 @@
 #include <teb_local_planner/robot_footprint_model.h>
 
 // g2o lib stuff
-#include "g2o/core/sparse_optimizer.h"
-#include "g2o/core/block_solver.h"
-#include "g2o/core/factory.h"
-#include "g2o/core/optimization_algorithm_gauss_newton.h"
-#include "g2o/core/optimization_algorithm_levenberg.h"
-#include "g2o/solvers/csparse/linear_solver_csparse.h"
-#include "g2o/solvers/cholmod/linear_solver_cholmod.h"
+#include <g2o/core/sparse_optimizer.h>
+#include <g2o/core/block_solver.h>
+#include <g2o/core/factory.h>
+#include <g2o/core/optimization_algorithm_gauss_newton.h>
+#include <g2o/core/optimization_algorithm_levenberg.h>
+#include <g2o/solvers/csparse/linear_solver_csparse.h>
+#include <g2o/solvers/cholmod/linear_solver_cholmod.h>
 
 // g2o custom edges and vertices for the TEB planner
 #include <teb_local_planner/g2o_types/edge_velocity.h>

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -63,9 +63,8 @@
 #include <costmap_converter/ObstacleMsg.h>
 
 // transforms
-#include <tf/tf.h>
-#include <tf/transform_listener.h>
-#include <tf/transform_datatypes.h>
+#include <tf2/utils.h>
+#include <tf2_ros/buffer.h>
 
 // costmap
 #include <costmap_2d/costmap_2d_ros.h>
@@ -106,10 +105,10 @@ public:
   /**
     * @brief Initializes the teb plugin
     * @param name The name of the instance
-    * @param tf Pointer to a transform listener
+    * @param tf Pointer to a tf buffer
     * @param costmap_ros Cost map representing occupied and free space
     */
-  void initialize(std::string name, tf::TransformListener* tf, costmap_2d::Costmap2DROS* costmap_ros);
+  void initialize(std::string name, tf2_ros::Buffer *tf, costmap_2d::Costmap2DROS* costmap_ros);
 
   /**
     * @brief Set the plan that the teb local planner is following
@@ -248,13 +247,13 @@ protected:
     * If no pose within the specified treshold \c dist_behind_robot can be found,
     * nothing will be pruned and the method returns \c false.
     * @remarks Do not choose \c dist_behind_robot too small (not smaller the cellsize of the map), otherwise nothing will be pruned.
-    * @param tf A reference to a transform listener
+    * @param tf A reference to a tf buffer
     * @param global_pose The global pose of the robot
     * @param[in,out] global_plan The plan to be transformed
     * @param dist_behind_robot Distance behind the robot that should be kept [meters]
     * @return \c true if the plan is pruned, \c false in case of a transform exception or if no pose cannot be found inside the threshold
     */
-  bool pruneGlobalPlan(const tf::TransformListener& tf, const tf::Stamped<tf::Pose>& global_pose, 
+  bool pruneGlobalPlan(const tf2_ros::Buffer& tf, const geometry_msgs::PoseStamped& global_pose,
                        std::vector<geometry_msgs::PoseStamped>& global_plan, double dist_behind_robot=1);
   
   /**
@@ -263,7 +262,7 @@ protected:
     * The method replaces transformGlobalPlan as defined in base_local_planner/goal_functions.h 
     * such that the index of the current goal pose is returned as well as 
     * the transformation between the global plan and the planning frame.
-    * @param tf A reference to a transform listener
+    * @param tf A reference to a tf buffer
     * @param global_plan The plan to be transformed
     * @param global_pose The global pose of the robot
     * @param costmap A reference to the costmap being used so the window size for transforming can be computed
@@ -274,10 +273,10 @@ protected:
     * @param[out] tf_plan_to_global Transformation between the global plan and the global planning frame
     * @return \c true if the global plan is transformed, \c false otherwise
     */
-  bool transformGlobalPlan(const tf::TransformListener& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
-                           const tf::Stamped<tf::Pose>& global_pose,  const costmap_2d::Costmap2D& costmap,
+  bool transformGlobalPlan(const tf2_ros::Buffer& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
+                           const geometry_msgs::PoseStamped& global_pose,  const costmap_2d::Costmap2D& costmap,
                            const std::string& global_frame, double max_plan_length, std::vector<geometry_msgs::PoseStamped>& transformed_plan,
-                           int* current_goal_idx = NULL, tf::StampedTransform* tf_plan_to_global = NULL) const;
+                           int* current_goal_idx = NULL, geometry_msgs::TransformStamped* tf_plan_to_global = NULL) const;
     
   /**
     * @brief Estimate the orientation of a pose from the global_plan that is treated as a local goal for the local planner.
@@ -294,8 +293,8 @@ protected:
     * @param moving_average_length number of future poses of the global plan to be taken into account
     * @return orientation (yaw-angle) estimate
     */
-  double estimateLocalGoalOrientation(const std::vector<geometry_msgs::PoseStamped>& global_plan, const tf::Stamped<tf::Pose>& local_goal,
-                                      int current_goal_idx, const tf::StampedTransform& tf_plan_to_global, int moving_average_length=3) const;
+  double estimateLocalGoalOrientation(const std::vector<geometry_msgs::PoseStamped>& global_plan, const geometry_msgs::PoseStamped& local_goal,
+                                      int current_goal_idx, const geometry_msgs::TransformStamped& tf_plan_to_global, int moving_average_length=3) const;
         
         
   /**
@@ -354,7 +353,7 @@ private:
   // external objects (store weak pointers)
   costmap_2d::Costmap2DROS* costmap_ros_; //!< Pointer to the costmap ros wrapper, received from the navigation stack
   costmap_2d::Costmap2D* costmap_; //!< Pointer to the 2d costmap (obtained from the costmap ros wrapper)
-  tf::TransformListener* tf_; //!< pointer to Transform Listener
+  tf2_ros::Buffer* tf_; //!< pointer to tf buffer
     
   // internal objects (memory management owned)
   PlannerInterfacePtr planner_; //!< Instance of the underlying optimal planner class

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>teb_local_planner</name>
-  <version>0.6.6</version>
+  <version>0.7.0</version>
   <description>
     The teb_local_planner package implements a plugin
     to the base_local_planner of the 2D navigation stack.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>teb_local_planner</name>
-  <version>0.7.0</version>
+  <version>0.7.1</version>
   <description>
     The teb_local_planner package implements a plugin
     to the base_local_planner of the 2D navigation stack.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>teb_local_planner</name>
-  <version>0.8.0</version>
+  <version>0.8.1</version>
   <description>
     The teb_local_planner package implements a plugin
     to the base_local_planner of the 2D navigation stack.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>teb_local_planner</name>
-  <version>0.7.2</version>
+  <version>0.7.3</version>
   <description>
     The teb_local_planner package implements a plugin
     to the base_local_planner of the 2D navigation stack.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>teb_local_planner</name>
-  <version>0.7.1</version>
+  <version>0.7.2</version>
   <description>
     The teb_local_planner package implements a plugin
     to the base_local_planner of the 2D navigation stack.

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,8 @@
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
   
   <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>
@@ -40,8 +42,8 @@
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
-  <depend>tf</depend>
-  <depend>tf_conversions</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>teb_local_planner</name>
-  <version>0.7.3</version>
+  <version>0.8.0</version>
   <description>
     The teb_local_planner package implements a plugin
     to the base_local_planner of the 2D navigation stack.

--- a/src/obstacles.cpp
+++ b/src/obstacles.cpp
@@ -106,15 +106,15 @@ void PolygonObstacle::calcCentroid()
     // seach for the two outer points of the line with the maximum distance inbetween
     int i_cand = 0;
     int j_cand = 0;
-    double min_dist = std::numeric_limits<double>::max();
+    double max_dist = 0;
     for (int i=0; i< noVertices(); ++i)
     {
       for (int j=i+1; j< noVertices(); ++j) // start with j=i+1
       {
         double dist = (vertices_[j] - vertices_[i]).norm();
-        if (dist < min_dist)
+        if (dist > max_dist)
         {
-          min_dist = dist;
+          max_dist = dist;
           i_cand = i;
           j_cand = j;
         }

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -38,6 +38,7 @@
 
 #include <teb_local_planner/optimal_planner.h>
 #include <map>
+#include <memory>
 #include <limits>
 
 
@@ -153,10 +154,10 @@ boost::shared_ptr<g2o::SparseOptimizer> TebOptimalPlanner::initOptimizer()
 
   // allocating the optimizer
   boost::shared_ptr<g2o::SparseOptimizer> optimizer = boost::make_shared<g2o::SparseOptimizer>();
-  TEBLinearSolver* linearSolver = new TEBLinearSolver(); // see typedef in optimization.h
-  linearSolver->setBlockOrdering(true);
-  TEBBlockSolver* blockSolver = new TEBBlockSolver(linearSolver);
-  g2o::OptimizationAlgorithmLevenberg* solver = new g2o::OptimizationAlgorithmLevenberg(blockSolver);
+  std::unique_ptr<TEBLinearSolver> linear_solver(new TEBLinearSolver()); // see typedef in optimization.h
+  linear_solver->setBlockOrdering(true);
+  std::unique_ptr<TEBBlockSolver> block_solver(new TEBBlockSolver(std::move(linear_solver)));
+  g2o::OptimizationAlgorithmLevenberg* solver = new g2o::OptimizationAlgorithmLevenberg(std::move(block_solver));
 
   optimizer->setAlgorithm(solver);
   

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -55,7 +55,7 @@
 
 
 // register this planner as a BaseLocalPlanner plugin
-PLUGINLIB_DECLARE_CLASS(teb_local_planner, TebLocalPlannerROS, teb_local_planner::TebLocalPlannerROS, nav_core::BaseLocalPlanner)
+PLUGINLIB_EXPORT_CLASS(teb_local_planner::TebLocalPlannerROS, nav_core::BaseLocalPlanner)
 
 namespace teb_local_planner
 {

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -38,7 +38,8 @@
 
 #include <teb_local_planner/teb_local_planner_ros.h>
 
-#include <tf_conversions/tf_eigen.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 #include <boost/algorithm/string.hpp>
 
@@ -78,7 +79,7 @@ void TebLocalPlannerROS::reconfigureCB(TebLocalPlannerReconfigureConfig& config,
   cfg_.reconfigure(config);
 }
 
-void TebLocalPlannerROS::initialize(std::string name, tf::TransformListener* tf, costmap_2d::Costmap2DROS* costmap_ros)
+void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costmap_2d::Costmap2DROS* costmap_ros)
 {
   // check if the plugin is already initialized
   if(!initialized_)
@@ -225,16 +226,16 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
   goal_reached_ = false;  
   
   // Get robot pose
-  tf::Stamped<tf::Pose> robot_pose;
+  geometry_msgs::PoseStamped robot_pose;
   costmap_ros_->getRobotPose(robot_pose);
-  robot_pose_ = PoseSE2(robot_pose);
+  robot_pose_ = PoseSE2(robot_pose.pose);
     
   // Get robot velocity
-  tf::Stamped<tf::Pose> robot_vel_tf;
+  geometry_msgs::PoseStamped robot_vel_tf;
   odom_helper_.getRobotVel(robot_vel_tf);
-  robot_vel_.linear.x = robot_vel_tf.getOrigin().getX();
-  robot_vel_.linear.y = robot_vel_tf.getOrigin().getY();
-  robot_vel_.angular.z = tf::getYaw(robot_vel_tf.getRotation());
+  robot_vel_.linear.x = robot_vel_tf.pose.position.x;
+  robot_vel_.linear.y = robot_vel_tf.pose.position.y;
+  robot_vel_.angular.z = tf2::getYaw(robot_vel_tf.pose.orientation);
   
   // prune global plan to cut off parts of the past (spatially before the robot)
   pruneGlobalPlan(*tf_, robot_pose, global_plan_);
@@ -242,7 +243,7 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
   // Transform global plan to the frame of interest (w.r.t. the local costmap)
   std::vector<geometry_msgs::PoseStamped> transformed_plan;
   int goal_idx;
-  tf::StampedTransform tf_plan_to_global;
+  geometry_msgs::TransformStamped tf_plan_to_global;
   if (!transformGlobalPlan(*tf_, global_plan_, robot_pose, *costmap_, global_frame_, cfg_.trajectory.max_global_plan_lookahead_dist, 
                            transformed_plan, &goal_idx, &tf_plan_to_global))
   {
@@ -255,12 +256,11 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
     updateViaPointsContainer(transformed_plan, cfg_.trajectory.global_plan_viapoint_sep);
 
   // check if global goal is reached
-  tf::Stamped<tf::Pose> global_goal;
-  tf::poseStampedMsgToTF(global_plan_.back(), global_goal);
-  global_goal.setData( tf_plan_to_global * global_goal );
-  double dx = global_goal.getOrigin().getX() - robot_pose_.x();
-  double dy = global_goal.getOrigin().getY() - robot_pose_.y();
-  double delta_orient = g2o::normalize_theta( tf::getYaw(global_goal.getRotation()) - robot_pose_.theta() );
+  geometry_msgs::PoseStamped global_goal;
+  tf2::doTransform(global_plan_.back(), global_goal, tf_plan_to_global);
+  double dx = global_goal.pose.position.x - robot_pose_.x();
+  double dy = global_goal.pose.position.y - robot_pose_.y();
+  double delta_orient = g2o::normalize_theta( tf2::getYaw(global_goal.pose.orientation) - robot_pose_.theta() );
   if(fabs(std::sqrt(dx*dx+dy*dy)) < cfg_.goal_tolerance.xy_goal_tolerance
     && fabs(delta_orient) < cfg_.goal_tolerance.yaw_goal_tolerance
     && (!cfg_.goal_tolerance.complete_global_plan || via_points_.size() == 0))
@@ -282,19 +282,20 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
   }
               
   // Get current goal point (last point of the transformed plan)
-  tf::Stamped<tf::Pose> goal_point;
-  tf::poseStampedMsgToTF(transformed_plan.back(), goal_point);
-  robot_goal_.x() = goal_point.getOrigin().getX();
-  robot_goal_.y() = goal_point.getOrigin().getY();      
+  robot_goal_.x() = transformed_plan.back().pose.position.x;
+  robot_goal_.y() = transformed_plan.back().pose.position.y;
+  // Overwrite goal orientation if needed
   if (cfg_.trajectory.global_plan_overwrite_orientation)
   {
-    robot_goal_.theta() = estimateLocalGoalOrientation(global_plan_, goal_point, goal_idx, tf_plan_to_global);
+    robot_goal_.theta() = estimateLocalGoalOrientation(global_plan_, transformed_plan.back(), goal_idx, tf_plan_to_global);
     // overwrite/update goal orientation of the transformed plan with the actual goal (enable using the plan as initialization)
-    transformed_plan.back().pose.orientation = tf::createQuaternionMsgFromYaw(robot_goal_.theta());
+    tf2::Quaternion q;
+    q.setRPY(0, 0, robot_goal_.theta());
+    tf2::convert(q, transformed_plan.back().pose.orientation);
   }  
   else
   {
-    robot_goal_.theta() = tf::getYaw(goal_point.getRotation());
+    robot_goal_.theta() = tf2::getYaw(transformed_plan.back().pose.orientation);
   }
 
   // overwrite/update start of the transformed plan with the actual robot position (allows using the plan as initial trajectory)
@@ -302,7 +303,7 @@ bool TebLocalPlannerROS::computeVelocityCommands(geometry_msgs::Twist& cmd_vel)
   {
     transformed_plan.insert(transformed_plan.begin(), geometry_msgs::PoseStamped()); // insert start (not yet initialized)
   }
-  tf::poseTFToMsg(robot_pose, transformed_plan.front().pose); // update start;
+  transformed_plan.front() = robot_pose; // update start
     
   // clear currently existing obstacles
   obstacles_.clear();
@@ -505,14 +506,10 @@ void TebLocalPlannerROS::updateObstacleContainerWithCustomObstacles()
     Eigen::Affine3d obstacle_to_map_eig;
     try 
     {
-      tf::StampedTransform obstacle_to_map;
-      tf_->waitForTransform(global_frame_, ros::Time(0),
-            custom_obstacle_msg_.header.frame_id, ros::Time(0),
-            custom_obstacle_msg_.header.frame_id, ros::Duration(0.5));
-      tf_->lookupTransform(global_frame_, ros::Time(0),
-          custom_obstacle_msg_.header.frame_id, ros::Time(0), 
-          custom_obstacle_msg_.header.frame_id, obstacle_to_map);
-      tf::transformTFToEigen(obstacle_to_map, obstacle_to_map_eig);
+      geometry_msgs::TransformStamped obstacle_to_map =  tf_->lookupTransform(global_frame_, ros::Time(0),
+                                                                              custom_obstacle_msg_.header.frame_id, ros::Time(0),
+                                                                              custom_obstacle_msg_.header.frame_id, ros::Duration(0.5));
+      obstacle_to_map_eig = tf2::transformToEigen(obstacle_to_map);
     }
     catch (tf::TransformException ex)
     {
@@ -603,7 +600,7 @@ Eigen::Vector2d TebLocalPlannerROS::tfPoseToEigenVector2dTransRot(const tf::Pose
 }
       
       
-bool TebLocalPlannerROS::pruneGlobalPlan(const tf::TransformListener& tf, const tf::Stamped<tf::Pose>& global_pose, std::vector<geometry_msgs::PoseStamped>& global_plan, double dist_behind_robot)
+bool TebLocalPlannerROS::pruneGlobalPlan(const tf2_ros::Buffer& tf, const geometry_msgs::PoseStamped& global_pose, std::vector<geometry_msgs::PoseStamped>& global_plan, double dist_behind_robot)
 {
   if (global_plan.empty())
     return true;
@@ -611,10 +608,9 @@ bool TebLocalPlannerROS::pruneGlobalPlan(const tf::TransformListener& tf, const 
   try
   {
     // transform robot pose into the plan frame (we do not wait here, since pruning not crucial, if missed a few times)
-    tf::StampedTransform global_to_plan_transform;
-    tf.lookupTransform(global_plan.front().header.frame_id, global_pose.frame_id_, ros::Time(0), global_to_plan_transform);
-    tf::Stamped<tf::Pose> robot;
-    robot.setData( global_to_plan_transform * global_pose );
+    geometry_msgs::TransformStamped global_to_plan_transform = tf.lookupTransform(global_plan.front().header.frame_id, global_pose.header.frame_id, ros::Time(0));
+    geometry_msgs::PoseStamped robot;
+    tf2::doTransform(global_pose, robot, global_to_plan_transform);
     
     double dist_thresh_sq = dist_behind_robot*dist_behind_robot;
     
@@ -623,8 +619,8 @@ bool TebLocalPlannerROS::pruneGlobalPlan(const tf::TransformListener& tf, const 
     std::vector<geometry_msgs::PoseStamped>::iterator erase_end = it;
     while (it != global_plan.end())
     {
-      double dx = robot.getOrigin().x() - it->pose.position.x;
-      double dy = robot.getOrigin().y() - it->pose.position.y;
+      double dx = robot.pose.position.x - it->pose.position.x;
+      double dy = robot.pose.position.y - it->pose.position.y;
       double dist_sq = dx * dx + dy * dy;
       if (dist_sq < dist_thresh_sq)
       {
@@ -648,9 +644,9 @@ bool TebLocalPlannerROS::pruneGlobalPlan(const tf::TransformListener& tf, const 
 }
       
 
-bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
-                  const tf::Stamped<tf::Pose>& global_pose, const costmap_2d::Costmap2D& costmap, const std::string& global_frame, double max_plan_length,
-                  std::vector<geometry_msgs::PoseStamped>& transformed_plan, int* current_goal_idx, tf::StampedTransform* tf_plan_to_global) const
+bool TebLocalPlannerROS::transformGlobalPlan(const tf2_ros::Buffer& tf, const std::vector<geometry_msgs::PoseStamped>& global_plan,
+                  const geometry_msgs::PoseStamped& global_pose, const costmap_2d::Costmap2D& costmap, const std::string& global_frame, double max_plan_length,
+                  std::vector<geometry_msgs::PoseStamped>& transformed_plan, int* current_goal_idx, geometry_msgs::TransformStamped* tf_plan_to_global) const
 {
   // this method is a slightly modified version of base_local_planner/goal_functions.h
 
@@ -668,17 +664,12 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
     }
 
     // get plan_to_global_transform from plan frame to global_frame
-    tf::StampedTransform plan_to_global_transform;
-    tf.waitForTransform(global_frame, ros::Time::now(),
-    plan_pose.header.frame_id, plan_pose.header.stamp,
-    plan_pose.header.frame_id, ros::Duration(0.5));
-    tf.lookupTransform(global_frame, ros::Time(),
-    plan_pose.header.frame_id, plan_pose.header.stamp, 
-    plan_pose.header.frame_id, plan_to_global_transform);
+    geometry_msgs::TransformStamped plan_to_global_transform = tf.lookupTransform(global_frame, ros::Time(), plan_pose.header.frame_id, plan_pose.header.stamp,
+                                                                                  plan_pose.header.frame_id, ros::Duration(0.5));
 
     //let's get the pose of the robot in the frame of the plan
-    tf::Stamped<tf::Pose> robot_pose;
-    tf.transformPose(plan_pose.header.frame_id, global_pose, robot_pose);
+    geometry_msgs::PoseStamped robot_pose;
+    tf.transform(global_pose, robot_pose, plan_pose.header.frame_id);
 
     //we'll discard points on the plan that are outside the local costmap
     double dist_threshold = std::max(costmap.getSizeInCellsX() * costmap.getResolution() / 2.0,
@@ -694,8 +685,8 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
     //we need to loop to a point on the plan that is within a certain distance of the robot
     for(int j=0; j < (int)global_plan.size(); ++j)
     {
-      double x_diff = robot_pose.getOrigin().x() - global_plan[j].pose.position.x;
-      double y_diff = robot_pose.getOrigin().y() - global_plan[j].pose.position.y;
+      double x_diff = robot_pose.pose.position.x - global_plan[j].pose.position.x;
+      double y_diff = robot_pose.pose.position.y - global_plan[j].pose.position.y;
       double new_sq_dist = x_diff * x_diff + y_diff * y_diff;
       if (new_sq_dist > sq_dist_threshold)
         break;  // force stop if we have reached the costmap border
@@ -707,7 +698,6 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
       }
     }
     
-    tf::Stamped<tf::Pose> tf_pose;
     geometry_msgs::PoseStamped newer_pose;
     
     double plan_length = 0; // check cumulative Euclidean distance along the plan
@@ -716,16 +706,12 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
     while(i < (int)global_plan.size() && sq_dist <= sq_dist_threshold && (max_plan_length<=0 || plan_length <= max_plan_length))
     {
       const geometry_msgs::PoseStamped& pose = global_plan[i];
-      tf::poseStampedMsgToTF(pose, tf_pose);
-      tf_pose.setData(plan_to_global_transform * tf_pose);
-      tf_pose.stamp_ = plan_to_global_transform.stamp_;
-      tf_pose.frame_id_ = global_frame;
-      tf::poseStampedTFToMsg(tf_pose, newer_pose);
+      tf2::doTransform(pose, newer_pose, plan_to_global_transform);
 
       transformed_plan.push_back(newer_pose);
 
-      double x_diff = robot_pose.getOrigin().x() - global_plan[i].pose.position.x;
-      double y_diff = robot_pose.getOrigin().y() - global_plan[i].pose.position.y;
+      double x_diff = robot_pose.pose.position.x - global_plan[i].pose.position.x;
+      double y_diff = robot_pose.pose.position.y - global_plan[i].pose.position.y;
       sq_dist = x_diff * x_diff + y_diff * y_diff;
       
       // caclulate distance to previous pose
@@ -739,11 +725,7 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
     // the resulting transformed plan can be empty. In that case we explicitly inject the global goal.
     if (transformed_plan.empty())
     {
-      tf::poseStampedMsgToTF(global_plan.back(), tf_pose);
-      tf_pose.setData(plan_to_global_transform * tf_pose);
-      tf_pose.stamp_ = plan_to_global_transform.stamp_;
-      tf_pose.frame_id_ = global_frame;
-      tf::poseStampedTFToMsg(tf_pose, newer_pose);
+      tf2::doTransform(global_plan.back(), newer_pose, plan_to_global_transform);
 
       transformed_plan.push_back(newer_pose);
       
@@ -784,8 +766,8 @@ bool TebLocalPlannerROS::transformGlobalPlan(const tf::TransformListener& tf, co
     
       
       
-double TebLocalPlannerROS::estimateLocalGoalOrientation(const std::vector<geometry_msgs::PoseStamped>& global_plan, const tf::Stamped<tf::Pose>& local_goal,
-			        int current_goal_idx, const tf::StampedTransform& tf_plan_to_global, int moving_average_length) const
+double TebLocalPlannerROS::estimateLocalGoalOrientation(const std::vector<geometry_msgs::PoseStamped>& global_plan, const geometry_msgs::PoseStamped& local_goal,
+              int current_goal_idx, const geometry_msgs::TransformStamped& tf_plan_to_global, int moving_average_length) const
 {
   int n = (int)global_plan.size();
   
@@ -794,13 +776,16 @@ double TebLocalPlannerROS::estimateLocalGoalOrientation(const std::vector<geomet
   {
     if (current_goal_idx >= n-1) // we've exactly reached the goal
     {
-      return tf::getYaw(local_goal.getRotation());
+      return tf2::getYaw(local_goal.pose.orientation);
     }
     else
     {
-      tf::Quaternion global_orientation;
-      tf::quaternionMsgToTF(global_plan.back().pose.orientation, global_orientation);
-      return  tf::getYaw(tf_plan_to_global.getRotation() *  global_orientation );
+      tf2::Quaternion global_orientation;
+      tf2::convert(global_plan.back().pose.orientation, global_orientation);
+      tf2::Quaternion rotation;
+      tf2::convert(tf_plan_to_global.transform.rotation, rotation);
+      // TODO(roesmann): avoid conversion to tf2::Quaternion
+      return tf2::getYaw(rotation *  global_orientation);
     }     
   }
   
@@ -808,20 +793,18 @@ double TebLocalPlannerROS::estimateLocalGoalOrientation(const std::vector<geomet
   moving_average_length = std::min(moving_average_length, n-current_goal_idx-1 ); // maybe redundant, since we have checked the vicinity of the goal before
   
   std::vector<double> candidates;
-  tf::Stamped<tf::Pose> tf_pose_k = local_goal;
-  tf::Stamped<tf::Pose> tf_pose_kp1;
+  geometry_msgs::PoseStamped tf_pose_k = local_goal;
+  geometry_msgs::PoseStamped tf_pose_kp1;
   
   int range_end = current_goal_idx + moving_average_length;
   for (int i = current_goal_idx; i < range_end; ++i)
   {
     // Transform pose of the global plan to the planning frame
-    const geometry_msgs::PoseStamped& pose = global_plan.at(i+1);
-    tf::poseStampedMsgToTF(pose, tf_pose_kp1);
-    tf_pose_kp1.setData(tf_plan_to_global * tf_pose_kp1);
-      
+    tf2::doTransform(global_plan.at(i+1), tf_pose_kp1, tf_plan_to_global);
+
     // calculate yaw angle  
-    candidates.push_back( std::atan2(tf_pose_kp1.getOrigin().getY() - tf_pose_k.getOrigin().getY(),
-			  tf_pose_kp1.getOrigin().getX() - tf_pose_k.getOrigin().getX() ) );
+    candidates.push_back( std::atan2(tf_pose_kp1.pose.position.y - tf_pose_k.pose.position.y,
+        tf_pose_kp1.pose.position.x - tf_pose_k.pose.position.x ) );
     
     if (i<range_end-1) 
       tf_pose_k = tf_pose_kp1;


### PR DESCRIPTION
not finished yet

trying to fix #89 for different types of holonomic robot
I've tried the `omni_abs_vel` branch, it's not quite work
the change should be on both velocity and acceleration (and jerk, if any), and it is not `sqrt(vx^2+vy^2)`

This PR was (partly) used in Jingdong Robotics Challenge 2018