### PR TITLE
Do not ignore robot model on the association stage

### DIFF
--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -440,9 +440,8 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
         if(cfg_->obstacles.include_dynamic_obstacles && obst->isDynamic())
           continue;
 
-          // calculate distance to current pose
-          // TODO we ignore the robot footprint here in the association stage
-          double dist = obst->getMinimumDistance(teb_.Pose(i).position());
+          // calculate distance to robot model
+          double dist = robot_model_->calculateDistance(teb_.Pose(i), obst.get());
           
           // force considering obstacle if really close to the current pose
         if (dist < cfg_->obstacles.min_obstacle_dist*cfg_->obstacles.obstacle_association_force_inclusion_factor)


### PR DESCRIPTION
This is important mostly for polygon footprint_model; with current code, almost no obstacles are considered, as with polygon footprint_model min_obstacle_dist is typically very small, possibly equal to footprint padding on costmaps.

But could also be that I misinterpreting the code... so in that case feel free to reject this!

Please ignore white spaces when comparing, as CLion doesn't like trailing white spaces