### PR TITLE
Add nonlinear part to obstacle cost to improve narrow gap

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -274,6 +274,10 @@ grp_optimization.add("weight_adapt_factor", double_t, 0,
   "Some special weights (currently 'weight_obstacle') are repeatedly scaled by this factor in each outer TEB iteration (weight_new: weight_old * factor); Increasing weights iteratively instead of setting a huge value a-priori leads to better numerical conditions of the underlying optimization problem.", 
   2, 1, 100) 
 
+grp_optimization.add("obstacle_cost_exponent", double_t, 0,
+	"Exponent for nonlinear obstacle cost (cost = linear_cost * obstacle_cost_exponent). Set to 1 to disable nonlinear cost (default)",
+	1, 0.01, 100)
+
   
   
 # Homotopy Class Planner

--- a/include/teb_local_planner/g2o_types/edge_obstacle.h
+++ b/include/teb_local_planner/g2o_types/edge_obstacle.h
@@ -217,10 +217,24 @@ public:
 
     double dist = robot_model_->calculateDistance(bandpt->pose(), _measurement);
 
+    // Original "straight line" obstacle cost. The max possible value
+    // before weighting is min_obstacle_dist
     _error[0] = penaltyBoundFromBelow(dist, cfg_->obstacles.min_obstacle_dist, cfg_->optim.penalty_epsilon);
+
+    if (cfg_->optim.obstacle_cost_exponent != 1.0 && cfg_->obstacles.min_obstacle_dist > 0.0)
+    {
+      // Optional non-linear cost. Note the max cost (before weighting) is
+      // the same as the straight line version and that all other costs are
+      // below the straight line (for positive exponent), so it may be
+      // necessary to increase weight_obstacle and/or the inflation_weight
+      // when using larger exponents.
+      _error[0] = cfg_->obstacles.min_obstacle_dist * std::pow(_error[0] / cfg_->obstacles.min_obstacle_dist, cfg_->optim.obstacle_cost_exponent);
+    }
+
+    // Additional linear inflation cost
     _error[1] = penaltyBoundFromBelow(dist, cfg_->obstacles.inflation_dist, 0.0);
 
-    
+
     ROS_ASSERT_MSG(std::isfinite(_error[0]) && std::isfinite(_error[1]), "EdgeObstacle::computeError() _error[0]=%f, _error[1]=%f\n",_error[0], _error[1]);
   }
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -157,6 +157,7 @@ public:
     double weight_prefer_rotdir; //!< Optimization weight for preferring a specific turning direction (-> currently only activated if an oscillation is detected, see 'oscillation_recovery'
     
     double weight_adapt_factor; //!< Some special weights (currently 'weight_obstacle') are repeatedly scaled by this factor in each outer TEB iteration (weight_new = weight_old*factor); Increasing weights iteratively instead of setting a huge value a-priori leads to better numerical conditions of the underlying optimization problem.
+    double obstacle_cost_exponent; //!< Exponent for nonlinear obstacle cost (cost = linear_cost * obstacle_cost_exponent). Set to 1 to disable nonlinear cost (default)
   } optim; //!< Optimization related parameters
   
   

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -121,6 +121,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("weight_viapoint", optim.weight_viapoint, optim.weight_viapoint);
   nh.param("weight_prefer_rotdir", optim.weight_prefer_rotdir, optim.weight_prefer_rotdir);
   nh.param("weight_adapt_factor", optim.weight_adapt_factor, optim.weight_adapt_factor);
+  nh.param("obstacle_cost_exponent", optim.obstacle_cost_exponent, optim.obstacle_cost_exponent);
   
   // Homotopy Class Planner
   nh.param("enable_homotopy_class_planning", hcp.enable_homotopy_class_planning, hcp.enable_homotopy_class_planning); 
@@ -228,6 +229,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   optim.weight_dynamic_obstacle_inflation = cfg.weight_dynamic_obstacle_inflation;
   optim.weight_viapoint = cfg.weight_viapoint;
   optim.weight_adapt_factor = cfg.weight_adapt_factor;
+  optim.obstacle_cost_exponent = cfg.obstacle_cost_exponent;
   
   // Homotopy Class Planner
   hcp.enable_multithreading = cfg.enable_multithreading;


### PR DESCRIPTION
This solves a major problem when the robot is faced with a narrow gap
that the global planner wants to traverse. The previous straight-line
obstacle cost function does not work well when there is a sufficiently
close obstacle on the left and right that the straight lines overlap.

The sum of two straight lines with opposite slope is a horizontal line,
which has zero derivative. Thus, there is no net force from obstacles
pushing poses to the center of the gap. So other slopes in the
optimization graph tend to pull these poses onto an obstacle, causing the
planned trajectory to be rejected, resetting the planner from the global
plan. We can stay in an endless loop in this case.

Reducing the obstacle weight helps a little bit in this case because the
solver becomes more stable. However, this makes it hard to avoid turning
a corner of a non-round robot into a nearby obstacle because the
gentle straight line slope of the obstacle cost is insufficient to
overcome other forces.

The new solution is to add a nonlinear cost component that will:
1. Make the minimum cost point between left & right obstacles be
in the middle.

2. Drive the cost very high as distance to obstacle aproaches zero. This
helps prevent us from turning a corner into an obstacle. Instead,
the solver will typically pull forward or backward in a slight
turn until clear enough to turn the desired direction, much like a
human driver would.

The new parameter, obstacle_cost_exponent, controls how nonlinear
the obstacle error function will be. The default is 1.0 which preserves
existing behavior.  I have found that setting the exponent to 4.0 and
increasing weight_obstacle to 100 (from 10) leads to excellent
narrow gap performance on our robot.

This solves the following open issues:
https://github.com/rst-tu-dortmund/teb_local_planner/issues/28
https://github.com/rst-tu-dortmund/teb_local_planner/issues/16