### PR TITLE
Include optimizer weights in path selection

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -298,7 +298,7 @@ grp_hcp.add("selection_prefer_initial_plan", double_t, 0,
 
 grp_hcp.add("selection_obst_cost_scale", double_t, 0, 
   "Extra scaling of obstacle cost terms just for selecting the 'best' candidate (new_obst_cost: obst_cost*factor)", 
-  100.0, 0, 1000) 
+  2.0, 0, 1000) 
 
 grp_hcp.add("selection_viapoint_cost_scale", double_t, 0, 
   "Extra scaling of via-point cost terms just for selecting the 'best' candidate. (new_viapt_cost: viapt_cost*factor)", 

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -998,38 +998,19 @@ void TebOptimalPlanner::computeCurrentCost(double obst_cost_scale, double viapoi
   // since we aren't storing edge pointers, we need to check every edge
   for (std::vector<g2o::OptimizableGraph::Edge*>::const_iterator it = optimizer_->activeEdges().begin(); it!= optimizer_->activeEdges().end(); it++)
   {
-    EdgeObstacle* edge_obstacle = dynamic_cast<EdgeObstacle*>(*it);
-    if (edge_obstacle!=NULL)
+    double cur_cost = (*it)->chi2();
+
+    if (dynamic_cast<EdgeObstacle*>(*it) != nullptr
+        || dynamic_cast<EdgeInflatedObstacle*>(*it) != nullptr
+        || dynamic_cast<EdgeDynamicObstacle*>(*it) != nullptr)
     {
-      cost_ += edge_obstacle->getError().squaredNorm() * obst_cost_scale;
-      continue;
+      cur_cost *= obst_cost_scale;
     }
-    
-    EdgeInflatedObstacle* edge_inflated_obstacle = dynamic_cast<EdgeInflatedObstacle*>(*it);
-    if (edge_inflated_obstacle!=NULL)
+    else if (dynamic_cast<EdgeViaPoint*>(*it) != nullptr)
     {
-      cost_ += std::sqrt(std::pow(edge_inflated_obstacle->getError()[0],2) * obst_cost_scale 
-               + std::pow(edge_inflated_obstacle->getError()[1],2));
-      continue;
+      cur_cost *= viapoint_cost_scale;
     }
-    
-    EdgeDynamicObstacle* edge_dyn_obstacle = dynamic_cast<EdgeDynamicObstacle*>(*it);
-    if (edge_dyn_obstacle!=NULL)
-    {
-      cost_ += edge_dyn_obstacle->getError().squaredNorm() * obst_cost_scale;
-      continue;
-    }
-    
-    EdgeViaPoint* edge_viapoint = dynamic_cast<EdgeViaPoint*>(*it);
-    if (edge_viapoint!=NULL)
-    {
-      cost_ += edge_viapoint->getError().squaredNorm() * viapoint_cost_scale;
-      continue;
-    }
-    else
-    {
-      cost_ += (*it)->chi2();
-    }
+    cost_ += cur_cost;
   }
 
   // delete temporary created graph

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -998,41 +998,6 @@ void TebOptimalPlanner::computeCurrentCost(double obst_cost_scale, double viapoi
   // since we aren't storing edge pointers, we need to check every edge
   for (std::vector<g2o::OptimizableGraph::Edge*>::const_iterator it = optimizer_->activeEdges().begin(); it!= optimizer_->activeEdges().end(); it++)
   {
-    EdgeTimeOptimal* edge_time_optimal = dynamic_cast<EdgeTimeOptimal*>(*it);
-    if (edge_time_optimal!=NULL && !alternative_time_cost)
-    {
-      cost_ += edge_time_optimal->chi2();
-      continue;
-    }
-
-    EdgeKinematicsDiffDrive* edge_kinematics_dd = dynamic_cast<EdgeKinematicsDiffDrive*>(*it);
-    if (edge_kinematics_dd!=NULL)
-    {
-      cost_ += edge_kinematics_dd->chi2();
-      continue;
-    }
-    
-    EdgeKinematicsCarlike* edge_kinematics_cl = dynamic_cast<EdgeKinematicsCarlike*>(*it);
-    if (edge_kinematics_cl!=NULL)
-    {
-      cost_ += edge_kinematics_cl->chi2();
-      continue;
-    }
-    
-    EdgeVelocity* edge_velocity = dynamic_cast<EdgeVelocity*>(*it);
-    if (edge_velocity!=NULL)
-    {
-      cost_ += edge_velocity->chi2();
-      continue;
-    }
-    
-    EdgeAcceleration* edge_acceleration = dynamic_cast<EdgeAcceleration*>(*it);
-    if (edge_acceleration!=NULL)
-    {
-      cost_ += edge_acceleration->chi2();
-      continue;
-    }
-    
     EdgeObstacle* edge_obstacle = dynamic_cast<EdgeObstacle*>(*it);
     if (edge_obstacle!=NULL)
     {
@@ -1060,6 +1025,10 @@ void TebOptimalPlanner::computeCurrentCost(double obst_cost_scale, double viapoi
     {
       cost_ += edge_viapoint->getError().squaredNorm() * viapoint_cost_scale;
       continue;
+    }
+    else
+    {
+      cost_ += (*it)->chi2();
     }
   }
 

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -1001,35 +1001,35 @@ void TebOptimalPlanner::computeCurrentCost(double obst_cost_scale, double viapoi
     EdgeTimeOptimal* edge_time_optimal = dynamic_cast<EdgeTimeOptimal*>(*it);
     if (edge_time_optimal!=NULL && !alternative_time_cost)
     {
-      cost_ += edge_time_optimal->getError().squaredNorm();
+      cost_ += edge_time_optimal->chi2();
       continue;
     }
 
     EdgeKinematicsDiffDrive* edge_kinematics_dd = dynamic_cast<EdgeKinematicsDiffDrive*>(*it);
     if (edge_kinematics_dd!=NULL)
     {
-      cost_ += edge_kinematics_dd->getError().squaredNorm();
+      cost_ += edge_kinematics_dd->chi2();
       continue;
     }
     
     EdgeKinematicsCarlike* edge_kinematics_cl = dynamic_cast<EdgeKinematicsCarlike*>(*it);
     if (edge_kinematics_cl!=NULL)
     {
-      cost_ += edge_kinematics_cl->getError().squaredNorm();
+      cost_ += edge_kinematics_cl->chi2();
       continue;
     }
     
     EdgeVelocity* edge_velocity = dynamic_cast<EdgeVelocity*>(*it);
     if (edge_velocity!=NULL)
     {
-      cost_ += edge_velocity->getError().squaredNorm();
+      cost_ += edge_velocity->chi2();
       continue;
     }
     
     EdgeAcceleration* edge_acceleration = dynamic_cast<EdgeAcceleration*>(*it);
     if (edge_acceleration!=NULL)
     {
-      cost_ += edge_acceleration->getError().squaredNorm();
+      cost_ += edge_acceleration->chi2();
       continue;
     }
     


### PR DESCRIPTION
Most of the weights used in path optimization were being ignored when
calculating the cost of candidate paths in order to identify the best
one when using the HomotopyClassPlanner. Furthermore,
selection_obst_cost_scale and selection_viapoint_cost_scale were not
really doing what the parameter description suggests because the cost
ignored the weights used in optimization.

This fixes a problem where the HomotopyClassPlanner would not choose a
forward-moving candidate path over a backward-moving one despite setting
weight_kinematics_formward_drive very high.

NOTE: By now including the optimizer's obstacle weights, it no longer
makes sense to set selection_obst_cost_scale very high, so reduce its
default to a much lower value.
