### PR TITLE
Changing isTrajectoryFeasible function to allow for a more accurate l…

### DIFF
--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -82,6 +82,7 @@ public:
     double force_reinit_new_goal_dist; //!< Reinitialize the trajectory if a previous goal is updated with a seperation of more than the specified value in meters (skip hot-starting)
     int feasibility_check_no_poses; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
     bool publish_feedback; //!< Publish planner feedback containing the full trajectory and a list of active obstacles (should be enabled only for evaluation or debugging purposes)
+    double min_resolution_collision_check_angular; //! Min angular resolution used during the costmap collision check. If not respected, intermediate samples are added. [rad]
   } trajectory; //!< Trajectory related parameters
     
   //! Robot related parameters
@@ -236,6 +237,7 @@ public:
     trajectory.force_reinit_new_goal_dist = 1;
     trajectory.feasibility_check_no_poses = 5;
     trajectory.publish_feedback = false;
+    trajectory.min_resolution_collision_check_angular = M_PI;
     
     // Robot
          

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -64,6 +64,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("force_reinit_new_goal_dist", trajectory.force_reinit_new_goal_dist, trajectory.force_reinit_new_goal_dist);
   nh.param("feasibility_check_no_poses", trajectory.feasibility_check_no_poses, trajectory.feasibility_check_no_poses);
   nh.param("publish_feedback", trajectory.publish_feedback, trajectory.publish_feedback);
+  nh.param("min_resolution_collision_check_angular", trajectory.min_resolution_collision_check_angular, trajectory.min_resolution_collision_check_angular);
   
   // Robot
   nh.param("max_vel_x", robot.max_vel_x, robot.max_vel_x);


### PR DESCRIPTION
The function isTrajectoryFeasible currently adds one intermediate check pose whenever the distance between 2 poses is bigger than the robot's inscribed radius.

If, due to a bad optimization, this discontinuities are very big, or if the consecutive orientations of the robot are not properly sampled, the check might report false negatives.

The applied changes properly handle this cases, forcing a minimum angle and distance resolution during the feasibility check.

With this change the planner can for example discard plans like the following:

![plan_to_be_discarted](https://user-images.githubusercontent.com/9111641/59506367-497ba280-8ea8-11e9-9d03-dc2a17093809.jpg)

The angular resolution is defaulted to PI in order to not change the current behaviour, a value <= PI / 4 is recommended.


