### PR TITLE
Adding more checks for hcp.max_number_classes

### DIFF
--- a/src/graph_search.cpp
+++ b/src/graph_search.cpp
@@ -94,7 +94,8 @@ void lrKeyPointGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, dou
 {
   // Clear existing graph and paths
   clearGraph();
-
+  if((int)hcp_->getTrajectoryContainer().size() >= cfg_->hcp.max_number_classes)
+    return;
   // Direction-vector between start and goal and normal-vector:
   Eigen::Vector2d diff = goal.position()-start.position();
 
@@ -220,7 +221,8 @@ void ProbRoadmapGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, do
 {
   // Clear existing graph and paths
   clearGraph();
-
+  if((int)hcp_->getTrajectoryContainer().size() >= cfg_->hcp.max_number_classes)
+    return;
   // Direction-vector between start and goal and normal-vector:
   Eigen::Vector2d diff = goal.position()-start.position();
   double start_goal_dist = diff.norm();

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -349,6 +349,8 @@ void HomotopyClassPlanner::exploreEquivalenceClassesAndInitTebs(const PoseSE2& s
 
 TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const PoseSE2& start, const PoseSE2& goal, const geometry_msgs::Twist* start_velocity)
 {
+  if(tebs_.size() >= cfg_->hcp.max_number_classes)
+    return TebOptimalPlannerPtr();
   TebOptimalPlannerPtr candidate =  TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, robot_model_));
 
   candidate->teb().initTrajectoryToGoal(start, goal, 0, cfg_->robot.max_vel_x, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
@@ -372,6 +374,8 @@ TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const PoseSE2& start
 
 TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const std::vector<geometry_msgs::PoseStamped>& initial_plan, const geometry_msgs::Twist* start_velocity)
 {
+  if(tebs_.size() >= cfg_->hcp.max_number_classes)
+    return TebOptimalPlannerPtr();
   TebOptimalPlannerPtr candidate = TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, robot_model_));
 
   candidate->teb().initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, true, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);


### PR DESCRIPTION
Not generating the homotopy exploration graph and not adding new candidates if the max number of allowed classes is already reached.

This prevents some unnecessary computation.