### PR TITLE
Allow scripts to be executable and usable by rosrun after catkin_make…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,10 +221,16 @@ target_link_libraries(test_optim_node
 
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+install(PROGRAMS
+  scripts/cmd_vel_to_ackermann_drive.py
+  scripts/export_to_mat.py
+  scripts/export_to_svg.py
+  scripts/publish_dynamic_obstacle.py
+  scripts/publish_test_obstacles.py
+  scripts/publish_viapoints.py
+  scripts/visualize_velocity_profile.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 ## Mark executables and/or libraries for installation
 install(TARGETS teb_local_planner


### PR DESCRIPTION
… install and through the catkin release process

Otherwise, scripts are installed to the catkin share directory as non-executables. With this fix, it'll allow them to be run by 'rosrun' and will be installed to the catkin BIN directory which marks them as executables on install.