### PR TITLE
Minimize path length

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -247,8 +247,12 @@ grp_optimization.add("weight_kinematics_turning_radius", double_t, 0,
   1, 0, 1000) 
 
 grp_optimization.add("weight_optimaltime", double_t, 0, 
-	"Optimization weight for contracting the trajectory w.r.t transition time", 
+        "Optimization weight for contracting the trajectory w.r.t. transition time",
 	1, 0, 1000) 
+
+grp_optimization.add("weight_shortest_path", double_t, 0,
+        "Optimization weight for contracting the trajectory w.r.t. path length",
+        0, 0, 100)
 
 grp_optimization.add("weight_obstacle", double_t, 0, 
 	"Optimization weight for satisfying a minimum seperation from obstacles",

--- a/include/teb_local_planner/g2o_types/edge_shortest_path.h
+++ b/include/teb_local_planner/g2o_types/edge_shortest_path.h
@@ -1,0 +1,89 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016,
+ *  TU Dortmund - Institute of Control Theory and Systems Engineering.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the institute nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Notes:
+ * The following class is derived from a class defined by the
+ * g2o-framework. g2o is licensed under the terms of the BSD License.
+ * Refer to the base class source for detailed licensing information.
+ *
+ * Author: Christoph Rösmann
+ *********************************************************************/
+
+#ifndef EDGE_SHORTEST_PATH_H_
+#define EDGE_SHORTEST_PATH_H_
+
+#include <float.h>
+
+#include <base_local_planner/BaseLocalPlannerConfig.h>
+
+#include <teb_local_planner/g2o_types/base_teb_edges.h>
+#include <teb_local_planner/g2o_types/vertex_pose.h>
+
+#include <Eigen/Core>
+
+namespace teb_local_planner {
+
+/**
+ * @class EdgeShortestPath
+ * @brief Edge defining the cost function for minimizing the Euclidean distance between two consectuive poses.
+ *
+ * @see TebOptimalPlanner::AddEdgesShortestPath
+ */
+class EdgeShortestPath : public BaseTebBinaryEdge<1, double, VertexPose, VertexPose> {
+public:
+  /**
+   * @brief Construct edge.
+   */
+  EdgeShortestPath() { this->setMeasurement(0.); }
+
+  /**
+   * @brief Actual cost function
+   */
+  void computeError() {
+    ROS_ASSERT_MSG(cfg_, "You must call setTebConfig on EdgeShortestPath()");
+    const VertexPose *pose1 = static_cast<const VertexPose*>(_vertices[0]);
+    const VertexPose *pose2 = static_cast<const VertexPose*>(_vertices[1]);
+    _error[0] = (pose2->position() - pose1->position()).norm();
+
+    ROS_ASSERT_MSG(std::isfinite(_error[0]), "EdgeShortestPath::computeError() _error[0]=%f\n", _error[0]);
+  }
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+
+} // end namespace
+
+#endif /* EDGE_SHORTEST_PATH_H_ */

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -64,6 +64,7 @@
 #include <teb_local_planner/g2o_types/edge_acceleration.h>
 #include <teb_local_planner/g2o_types/edge_kinematics.h>
 #include <teb_local_planner/g2o_types/edge_time_optimal.h>
+#include <teb_local_planner/g2o_types/edge_shortest_path.h>
 #include <teb_local_planner/g2o_types/edge_obstacle.h>
 #include <teb_local_planner/g2o_types/edge_dynamic_obstacle.h>
 #include <teb_local_planner/g2o_types/edge_via_point.h>
@@ -605,6 +606,14 @@ protected:
    * @see optimizeGraph
    */
   void AddEdgesTimeOptimal();
+
+  /**
+   * @brief Add all edges (local cost functions) for minimizing the path length
+   * @see EdgeShortestPath
+   * @see buildGraph
+   * @see optimizeGraph
+   */
+  void AddEdgesShortestPath();
   
   /**
    * @brief Add all edges (local cost functions) related to keeping a distance from static obstacles

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -148,7 +148,8 @@ public:
     double weight_kinematics_nh; //!< Optimization weight for satisfying the non-holonomic kinematics
     double weight_kinematics_forward_drive; //!< Optimization weight for forcing the robot to choose only forward directions (positive transl. velocities, only diffdrive robot)
     double weight_kinematics_turning_radius; //!< Optimization weight for enforcing a minimum turning radius (carlike robots)
-    double weight_optimaltime; //!< Optimization weight for contracting the trajectory w.r.t transition time
+    double weight_optimaltime; //!< Optimization weight for contracting the trajectory w.r.t. transition time
+    double weight_shortest_path; //!< Optimization weight for contracting the trajectory w.r.t. path length
     double weight_obstacle; //!< Optimization weight for satisfying a minimum separation from obstacles
     double weight_inflation; //!< Optimization weight for the inflation penalty (should be small)
     double weight_dynamic_obstacle; //!< Optimization weight for satisfying a minimum separation from dynamic obstacles    
@@ -291,6 +292,7 @@ public:
     optim.weight_kinematics_forward_drive = 1;
     optim.weight_kinematics_turning_radius = 1;
     optim.weight_optimaltime = 1;
+    optim.weight_shortest_path = 0;
     optim.weight_obstacle = 50;
     optim.weight_inflation = 0.1;
     optim.weight_dynamic_obstacle = 50;

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -114,6 +114,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("weight_kinematics_forward_drive", optim.weight_kinematics_forward_drive, optim.weight_kinematics_forward_drive);
   nh.param("weight_kinematics_turning_radius", optim.weight_kinematics_turning_radius, optim.weight_kinematics_turning_radius);
   nh.param("weight_optimaltime", optim.weight_optimaltime, optim.weight_optimaltime);
+  nh.param("weight_shortest_path", optim.weight_shortest_path, optim.weight_shortest_path);
   nh.param("weight_obstacle", optim.weight_obstacle, optim.weight_obstacle);
   nh.param("weight_inflation", optim.weight_inflation, optim.weight_inflation);
   nh.param("weight_dynamic_obstacle", optim.weight_dynamic_obstacle, optim.weight_dynamic_obstacle);    
@@ -222,6 +223,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   optim.weight_kinematics_forward_drive = cfg.weight_kinematics_forward_drive;
   optim.weight_kinematics_turning_radius = cfg.weight_kinematics_turning_radius;
   optim.weight_optimaltime = cfg.weight_optimaltime;
+  optim.weight_shortest_path = cfg.weight_shortest_path;
   optim.weight_obstacle = cfg.weight_obstacle;
   optim.weight_inflation = cfg.weight_inflation;
   optim.weight_dynamic_obstacle = cfg.weight_dynamic_obstacle;


### PR DESCRIPTION
This PR adds an edge to minimize the path length.
However, this edge should be used in combination with the time-optimal edge
since otherwise the time intervals are underconstrained.

The minimization of time and path lengths tries to avoid many motion traversals that often originate from the only-time-optimal formulation. 

Further tests and simulations need to be carried out to determine whether this change is actually useful.