### PR TITLE
New detours detection

### DIFF
--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -281,15 +281,6 @@ public:
    */
   void exploreEquivalenceClassesAndInitTebs(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, const geometry_msgs::Twist* start_vel);
 
-
-  /**
-   * @brief Check all available trajectories (TEBs) for detours and delete found ones.
-   * @see TimedElasticBand::detectDetoursBackwards
-   * @param threshold Threshold paramter for allowed orientation changes (below 0 -> greater than 90 deg)
-   */
-  void deleteTebDetours(double threshold=0.0);
-
-
   /**
    * @brief Add a new Teb to the internal trajectory container, if this teb constitutes a new equivalence class. Initialize it using a generic 2D reference path
    *
@@ -487,7 +478,7 @@ public:
   /**
    * @brief Internal helper function that adds a new equivalence class to the list of known classes only if it is unique.
    * @param eq_class equivalence class that should be tested
-   * @param lock if \c true, exclude the H-signature from deletion, e.g. in deleteTebDetours().
+   * @param lock if \c true, exclude the H-signature from deletion.
    * @return \c true if the h-signature was added and no duplicate was found, \c false otherwise
    */
   bool addEquivalenceClassIfNew(const EquivalenceClassPtr& eq_class, bool lock=false);
@@ -519,7 +510,7 @@ protected:
    * First all old h-signatures are deleted, since they could be invalid for this planning step (obstacle position may changed).
    * Afterwards the h-signatures are calculated for each existing TEB/trajectory and is inserted to the list of known h-signatures.
    * Doing this is important to prefer already optimized trajectories in contrast to initialize newly explored coarse paths.
-   * @param delete_detours if this param is \c true, all existing TEBs are cleared from detour-candidates by utilizing deleteTebDetours().
+   * @param delete_detours if this param is \c true, all existing TEBs are cleared from detour-candidates calling deletePlansGoingBackwards().
    */
   void renewAndAnalyzeOldTebs(bool delete_detours);
 

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -435,6 +435,23 @@ public:
         return true; // Found! Homotopy class already exists, therefore nothing added
       return false;
   }
+  /**
+   * @brief Checks if the orientation of the computed trajectories differs from that of the best plan of more than the
+   *  specified threshold and eventually deletes them.
+   * @param orient_threshold: Threshold paramter for allowed orientation changes in radians
+   * @param len_orientation_vector: length of the vector used to compute the start orientation
+   */
+  void deletePlansDetouringBackwards(const double orient_threshold, const double len_orientation_vector);
+  /**
+   * @brief Given a plan, computes its start orientation using a vector of length >= len_orientation_vector
+   *        starting from the initial pose.
+   * @param plan: Teb to be analyzed
+   * @param len_orientation_vector: min length of the vector used to compute the start orientation
+   * @param orientation: computed start orientation
+   * @return: Could the vector for the orientation check be computed? (False if the plan has no pose with a distance
+   *          > len_orientation_vector from the start poseq)
+   */
+  bool computeStartOrientation(const TebOptimalPlannerPtr plan, const double len_orientation_vector, double& orientation);
 
 
   /**

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -429,6 +429,7 @@ public:
   /**
    * @brief Checks if the orientation of the computed trajectories differs from that of the best plan of more than the
    *  specified threshold and eventually deletes them.
+   *  Also deletes detours with a duration much bigger than the duration of the best_teb (duration / best duration > max_ratio_detours_duration_best_duration).
    * @param orient_threshold: Threshold paramter for allowed orientation changes in radians
    * @param len_orientation_vector: length of the vector used to compute the start orientation
    */

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -188,6 +188,9 @@ public:
     
     bool visualize_hc_graph; //!< Visualize the graph that is created for exploring new homotopy classes.
     double visualize_with_time_as_z_axis_scale; //!< If this value is bigger than 0, the trajectory and obstacles are visualized in 3d using the time as the z-axis scaled by this value. Most useful for dynamic obstacles.
+    bool delete_detours_backwards; //!< If enabled, the planner will discard the plans detouring backwards with respect to the best plan
+    double detours_orientation_tolerance; //!< A plan is considered a detour if its start orientation differs more than this from the best plan
+    double length_start_orientation_vector; //!< Length of the vector used to compute the start orientation of a plan
   } hcp;
   
   //! Recovery/backup related parameters
@@ -328,6 +331,9 @@ public:
     
     hcp.visualize_hc_graph = false;
     hcp.visualize_with_time_as_z_axis_scale = 0.0;
+    hcp.delete_detours_backwards = true;
+    hcp.detours_orientation_tolerance = M_PI / 2.0;
+    hcp.length_start_orientation_vector = 0.4;
     
     // Recovery
     

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -191,6 +191,7 @@ public:
     bool delete_detours_backwards; //!< If enabled, the planner will discard the plans detouring backwards with respect to the best plan
     double detours_orientation_tolerance; //!< A plan is considered a detour if its start orientation differs more than this from the best plan
     double length_start_orientation_vector; //!< Length of the vector used to compute the start orientation of a plan
+    double max_ratio_detours_duration_best_duration; //!< Detours are discarted if their execution time / the execution time of the best teb is > this
   } hcp;
   
   //! Recovery/backup related parameters
@@ -334,6 +335,7 @@ public:
     hcp.delete_detours_backwards = true;
     hcp.detours_orientation_tolerance = M_PI / 2.0;
     hcp.length_start_orientation_vector = 0.4;
+    hcp.max_ratio_detours_duration_best_duration = 3.0;
     
     // Recovery
     

--- a/include/teb_local_planner/timed_elastic_band.h
+++ b/include/teb_local_planner/timed_elastic_band.h
@@ -625,22 +625,6 @@ public:
   double getAccumulatedDistance() const;
   
   /**
-   * @brief Detect whether the trajectory contains detours.
-   * 
-   * Two different cases forces the method to return \c true : \n
-   * 	1. The trajectory contain parts that increase the distance to the goal. \n
-   * 	   This is checked by comparing the orientations theta_i with the goal heading. \n
-   * 	   If the scalar product is below the \c threshold param, the method returns \c true.
-   * 	2. The trajectory consist of backwards motions at the beginning of the trajectory,
-   * 	   e.g. the second pose is behind the start pose w.r.t. to the same goal heading.
-   * 
-   * Detours are not critical, but can be takein into account if multiple trajectory candidates are avaiable.
-   * @param threshold Threshold paramter for allowed orientation changes (below 0 -> greater than 90 deg)
-   * @return \c true if one of both cases mentioned above are satisfied, false otherwise
-   */
-  bool detectDetoursBackwards(double threshold=0) const;
-  
-  /**
    * @brief Check if all trajectory points are contained in a specific region
    * 
    * The specific region is a circle around the current robot position (Pose(0)) with given radius \c radius.

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -733,6 +733,12 @@ void HomotopyClassPlanner::deletePlansDetouringBackwards(const double orient_thr
       it_teb = removeTeb(*it_teb);  // Plan detouring backwards
       continue;
     }
+    if(!it_teb->get()->isOptimized())
+    {
+      ROS_DEBUG("Removing a teb because it's not optimized");
+      it_teb = removeTeb(*it_teb);  // Deletes tebs that cannot be optimized (last optim call failed)
+      continue;
+    }
     ++it_teb;
   }
 }

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -118,8 +118,6 @@ bool HomotopyClassPlanner::plan(const PoseSE2& start, const PoseSE2& goal, const
   updateReferenceTrajectoryViaPoints(cfg_->hcp.viapoints_all_candidates);
   // Optimize all trajectories in alternative homotopy classes
   optimizeAllTEBs(cfg_->optim.no_inner_iterations, cfg_->optim.no_outer_iterations);
-  // Delete any detours
-  deleteTebDetours(-0.1);
   // Select which candidate (based on alternative homotopy classes) should be used
   selectBestTeb();
 
@@ -232,13 +230,6 @@ void HomotopyClassPlanner::renewAndAnalyzeOldTebs(bool delete_detours)
   TebOptPlannerContainer::iterator it_teb = has_best_teb ? std::next(tebs_.begin(), 1) : tebs_.begin();
   while(it_teb != tebs_.end())
   {
-    // delete Detours if there is at least one other TEB candidate left in the container
-    if (delete_detours && tebs_.size()>1 && it_teb->get()->teb().detectDetoursBackwards(-0.1))
-    {
-      it_teb = tebs_.erase(it_teb); // delete candidate and set iterator to the next valid candidate
-      continue;
-    }
-
     // calculate equivalence class for the current candidate
     EquivalenceClassPtr equivalence_class = calculateEquivalenceClass(it_teb->get()->teb().poses().begin(), it_teb->get()->teb().poses().end(), getCplxFromVertexPosePtr , obstacles_,
                                                                       it_teb->get()->teb().timediffs().begin(), it_teb->get()->teb().timediffs().end());
@@ -256,6 +247,8 @@ void HomotopyClassPlanner::renewAndAnalyzeOldTebs(bool delete_detours)
 
     ++it_teb;
   }
+  if(delete_detours)
+    deletePlansDetouringBackwards(cfg_->hcp.detours_orientation_tolerance, cfg_->hcp.length_start_orientation_vector);
 
   // Find multiple candidates and delete the one with higher cost
   // TODO: this code needs to be adpated. Erasing tebs from the teb container_ could make iteratores stored in the candidate list invalid!
@@ -339,7 +332,7 @@ void HomotopyClassPlanner::updateReferenceTrajectoryViaPoints(bool all_trajector
 void HomotopyClassPlanner::exploreEquivalenceClassesAndInitTebs(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, const geometry_msgs::Twist* start_vel)
 {
   // first process old trajectories
-  renewAndAnalyzeOldTebs(false);
+  renewAndAnalyzeOldTebs(cfg_->hcp.delete_detours_backwards);
 
   // inject initial plan if available and not yet captured
   if (initial_plan_)
@@ -388,7 +381,8 @@ TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const std::vector<ge
     return TebOptimalPlannerPtr();
   TebOptimalPlannerPtr candidate = TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, robot_model_));
 
-  candidate->teb().initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, true, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
+  candidate->teb().initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x,
+    cfg_->trajectory.global_plan_overwrite_orientation, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
 
   if (start_velocity)
     candidate->setVelocityStart(*start_velocity);
@@ -453,53 +447,6 @@ void HomotopyClassPlanner::optimizeAllTEBs(int iter_innerloop, int iter_outerloo
     {
       it_teb->get()->optimizeTEB(iter_innerloop,iter_outerloop, true, cfg_->hcp.selection_obst_cost_scale,
                                  cfg_->hcp.selection_viapoint_cost_scale, cfg_->hcp.selection_alternative_time_cost); // compute cost as well inside optimizeTEB (last argument = true)
-    }
-  }
-}
-
-void HomotopyClassPlanner::deleteTebDetours(double threshold)
-{
-  TebOptPlannerContainer::iterator it_teb = tebs_.begin();
-  EquivalenceClassContainer::iterator it_eqclasses = equivalence_classes_.begin();
-
-  if (tebs_.size() != equivalence_classes_.size())
-  {
-    ROS_ERROR("HomotopyClassPlanner::deleteTebDetours(): number of equivalence classes (%lu) and trajectories (%lu) does not match.", equivalence_classes_.size(), tebs_.size());
-    return;
-  }
-
-  bool modified;
-
-  while(it_teb != tebs_.end())
-  {
-    modified = false;
-
-    if (!it_eqclasses->second) // check if equivalence class is locked
-    {
-      // delete Detours if other TEBs will remain!
-      if (tebs_.size()>1 && (it_teb->get()->teb().detectDetoursBackwards(threshold) || !it_eqclasses->first->isReasonable()))
-      {
-        it_teb = tebs_.erase(it_teb);
-        it_eqclasses = equivalence_classes_.erase(it_eqclasses);
-        modified = true;
-        continue;
-      }
-    }
-
-    // Also delete tebs that cannot be optimized (last optim call failed)
-    // here, we ignore the lock-state, since we cannot keep trajectories that are not optimizable
-    if (!it_teb->get()->isOptimized())
-    {
-      it_teb = tebs_.erase(it_teb);
-      it_eqclasses = equivalence_classes_.erase(it_eqclasses);
-      modified = true;
-      ROS_DEBUG("HomotopyClassPlanner::deleteTebDetours(): removing candidate that was not optimized successfully");
-    }
-
-    if (!modified)
-    {
-      ++it_teb;
-      ++it_eqclasses;
     }
   }
 }
@@ -748,6 +695,67 @@ void HomotopyClassPlanner::computeCurrentCost(std::vector<double>& cost, double 
   {
     it_teb->get()->computeCurrentCost(cost, obst_cost_scale, viapoint_cost_scale, alternative_time_cost);
   }
+}
+
+void HomotopyClassPlanner::deletePlansDetouringBackwards(const double orient_threshold,
+  const double len_orientation_vector)
+{
+  if (tebs_.size() < 2 || !best_teb_ || std::find(tebs_.begin(), tebs_.end(), best_teb_) == tebs_.end() ||
+    best_teb_->teb().sizePoses() < 2)
+  {
+    return;  // A moving direction wasn't chosen yet
+  }
+  double current_movement_orientation;
+  if(!computeStartOrientation(best_teb_, len_orientation_vector, current_movement_orientation))
+    return;  // The plan is shorter than len_orientation_vector
+  for(auto it_teb = tebs_.begin(); it_teb != tebs_.end();)
+  {
+    if(*it_teb == best_teb_)  // The current plan should not be considered a detour
+    {
+      ++it_teb;
+      continue;
+    }
+    if((*it_teb)->teb().sizePoses() < 2)
+    {
+      ROS_DEBUG("Discarding a plan with less than 2 poses");
+      it_teb = removeTeb(*it_teb);
+      continue;
+    }
+    double plan_orientation;
+    if(!computeStartOrientation(*it_teb, len_orientation_vector, plan_orientation))
+    {
+      ROS_DEBUG("Failed to compute the start orientation for one of the tebs, likely close to the target");
+      it_teb = removeTeb(*it_teb);
+      continue;
+    }
+    if(fabs(g2o::normalize_theta(plan_orientation - current_movement_orientation)) > orient_threshold)
+    {
+      it_teb = removeTeb(*it_teb);  // Plan detouring backwards
+      continue;
+    }
+    ++it_teb;
+  }
+}
+
+bool HomotopyClassPlanner::computeStartOrientation(const TebOptimalPlannerPtr plan, const double len_orientation_vector,
+  double& orientation)
+{
+  VertexPose start_pose = plan->teb().Pose(0);
+  bool second_pose_found = false;
+  Eigen::Vector2d start_vector;
+  for(auto& pose : plan->teb().poses())
+  {
+    start_vector = start_pose.position() - pose->position();
+    if(start_vector.norm() > len_orientation_vector)
+    {
+      second_pose_found = true;
+      break;
+    }
+  }
+  if(!second_pose_found)  // The current plan is too short to make assumptions on the start orientation
+    return false;
+  orientation = std::atan2(start_vector[1], start_vector[0]);
+  return true;
 }
 
 

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -706,6 +706,7 @@ void HomotopyClassPlanner::deletePlansDetouringBackwards(const double orient_thr
     return;  // A moving direction wasn't chosen yet
   }
   double current_movement_orientation;
+  double best_plan_duration = std::max(best_teb_->teb().getSumOfAllTimeDiffs(), 1.0);
   if(!computeStartOrientation(best_teb_, len_orientation_vector, current_movement_orientation))
     return;  // The plan is shorter than len_orientation_vector
   for(auto it_teb = tebs_.begin(); it_teb != tebs_.end();)
@@ -737,6 +738,12 @@ void HomotopyClassPlanner::deletePlansDetouringBackwards(const double orient_thr
     {
       ROS_DEBUG("Removing a teb because it's not optimized");
       it_teb = removeTeb(*it_teb);  // Deletes tebs that cannot be optimized (last optim call failed)
+      continue;
+    }
+    if(it_teb->get()->teb().getSumOfAllTimeDiffs() / best_plan_duration > cfg_->hcp.max_ratio_detours_duration_best_duration)
+    {
+      ROS_DEBUG("Removing a teb because it's duration is much longer than that of the best teb");
+      it_teb = removeTeb(*it_teb);
       continue;
     }
     ++it_teb;

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -145,9 +145,11 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("viapoints_all_candidates", hcp.viapoints_all_candidates, hcp.viapoints_all_candidates);
   nh.param("visualize_hc_graph", hcp.visualize_hc_graph, hcp.visualize_hc_graph); 
   nh.param("visualize_with_time_as_z_axis_scale", hcp.visualize_with_time_as_z_axis_scale, hcp.visualize_with_time_as_z_axis_scale);
+  nh.param("delete_detours_backwards", hcp.delete_detours_backwards, hcp.delete_detours_backwards);
+  nh.param("detours_orientation_tolerance", hcp.detours_orientation_tolerance, hcp.detours_orientation_tolerance);
+  nh.param("length_start_orientation_vector", hcp.length_start_orientation_vector, hcp.length_start_orientation_vector);
   
   // Recovery
-  
   nh.param("shrink_horizon_backup", recovery.shrink_horizon_backup, recovery.shrink_horizon_backup);
   nh.param("shrink_horizon_min_duration", recovery.shrink_horizon_min_duration, recovery.shrink_horizon_min_duration);
   nh.param("oscillation_recovery", recovery.oscillation_recovery, recovery.oscillation_recovery);

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -148,6 +148,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("delete_detours_backwards", hcp.delete_detours_backwards, hcp.delete_detours_backwards);
   nh.param("detours_orientation_tolerance", hcp.detours_orientation_tolerance, hcp.detours_orientation_tolerance);
   nh.param("length_start_orientation_vector", hcp.length_start_orientation_vector, hcp.length_start_orientation_vector);
+  nh.param("max_ratio_detours_duration_best_duration", hcp.max_ratio_detours_duration_best_duration, hcp.max_ratio_detours_duration_best_duration);
   
   // Recovery
   nh.param("shrink_horizon_backup", recovery.shrink_horizon_backup, recovery.shrink_horizon_backup);

--- a/src/timed_elastic_band.cpp
+++ b/src/timed_elastic_band.cpp
@@ -547,46 +547,6 @@ int TimedElasticBand::findClosestTrajectoryPose(const Obstacle& obstacle, double
 }
 
 
-
-
-bool TimedElasticBand::detectDetoursBackwards(double threshold) const
-{
-  if (sizePoses()<2) return false;
-  
-  Eigen::Vector2d d_start_goal = BackPose().position() - Pose(0).position();
-  d_start_goal.normalize(); // using scalar_product without normalizing vectors first result in different threshold-effects
-
-  /// detect based on orientation
-  for(int i=0; i < sizePoses(); ++i)
-  {
-    Eigen::Vector2d orient_vector(cos( Pose(i).theta() ), sin( Pose(i).theta() ) );
-    if (orient_vector.dot(d_start_goal) < threshold)
-    {	
-      ROS_DEBUG("detectDetoursBackwards() - mark TEB for deletion: start-orientation vs startgoal-vec");
-      return true; // backward direction found
-    }
-  }
-  
-  /// check if upcoming configuration (next index) ist pushed behind the start (e.g. due to obstacles)
-  // TODO: maybe we need a small hysteresis?
-/*  for (unsigned int i=0;i<2;++i) // check only a few upcoming
-  {
-    if (i+1 >= sizePoses()) break;
-    Eigen::Vector2d start2conf = Pose(i+1).position() - Pose(0).position();
-    double dist = start2conf.norm();
-    start2conf = start2conf/dist; // normalize -> we don't use start2conf.normalize() since we want to use dist later
-    if (start2conf.dot(d_start_goal) < threshold && dist>0.01) // skip very small displacements
-    {
-      ROS_DEBUG("detectDetoursBackwards() - mark TEB for deletion: curvature look-ahead relative to startconf");
-      return true;
-    }
-  }*/	
-  return false;
-}
-
-
-
-
 void TimedElasticBand::updateAndPruneTEB(boost::optional<const PoseSE2&> new_start, boost::optional<const PoseSE2&> new_goal, int min_samples)
 {
   // first and simple approach: change only start confs (and virtual start conf for inital velocity)


### PR DESCRIPTION
As stated in the documentation, a plan is currently considered a detour if one of this cases occurs:

   1. The trajectory contains parts that increase the distance to the goal.
       This is checked by comparing the orientations theta_i with the goal heading
       If the scalar product is below the \c threshold param, the method returns true.
  2. The trajectory consist of backwards motions at the beginning of the trajectory,
       e.g. the second pose is behind the start pose w.r.t. to the same goal heading.

This approach unfortunately fails whenever the robot has to turn around a "long" obstacle (and has no other way to reach the target): the distance to the target might initially increase to later decrease, and the heading might be completely different from the start-goal heading.
The current implementation also forces the hcp planner to ignore the orientation of the initial plans provided, which again can result in unfeasible paths when detouring obstacles (see the picture below).

![bad_teb_orientation](https://user-images.githubusercontent.com/9111641/59998210-28147680-965f-11e9-88d0-31f5a82064c7.jpg)

The new discard logic uses a different approach: the start orientation of the current best-teb is considered to be the reference one; this is computed as the orientation of a vector starting in the first point of the trajectory and ending in the first pose whose distance is at least "length_start_orientation_vector" (see computeStartOrientation function).
The start orientation of the other plans is computed using the same approach: these are considered detours if their heading differs from that of the best teb of at least "detours_orientation_tolerance".

The user can now enable/disable this functionality through a parameter and choose to keep the orientation of the global plan with the parameter trajectory.global_plan_overwrite_orientation.