### PR TITLE
Avoiding h signature integration between coincident poses

### DIFF
--- a/include/teb_local_planner/h_signature.h
+++ b/include/teb_local_planner/h_signature.h
@@ -318,6 +318,8 @@ public:
           Eigen::Vector3d next_pose_with_time (nextpose(0), nextpose(1), next_transition_time);
 
           Eigen::Vector3d direction_vec = next_pose_with_time - pose_with_time;
+          if(direction_vec.norm() == 0)  // Coincident poses
+            continue;
           Eigen::Vector3d dl = 0.1 * direction_vec.normalized(); // Integrate with 10 steps between each pose
 
           for (Eigen::Vector3d position = pose_with_time; (position-pose_with_time).norm() <= direction_vec.norm(); position += dl)


### PR DESCRIPTION
The integration performed during the h-signature computation can result in an infinite loop if the direction vector has a null norm. Skipping poses coincident from a position point of view avoids this issue.