### PR TITLE
Implements both nav_core::BaseLocalPlanner and mbf_costmap_core::CostmapController abstract interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   nav_core
   nav_msgs
+  mbf_costmap_core
+  mbf_msgs
   roscpp
   std_msgs
   pluginlib

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -43,6 +43,7 @@
 
 // base local planner base class and utilities
 #include <nav_core/base_local_planner.h>
+#include <mbf_costmap_core/costmap_controller.h>
 #include <base_local_planner/goal_functions.h>
 #include <base_local_planner/odometry_helper_ros.h>
 #include <base_local_planner/costmap_model.h>
@@ -85,10 +86,11 @@ namespace teb_local_planner
 
 /**
   * @class TebLocalPlannerROS
-  * @brief Implements the actual abstract navigation stack routines of the teb_local_planner plugin
+  * @brief Implements both nav_core::BaseLocalPlanner and mbf_costmap_core::CostmapController abstract
+  * interfaces, so the teb_local_planner plugin can be used both in move_base and move_base_flex (MBF).
   * @todo Escape behavior, more efficient obstacle handling
   */
-class TebLocalPlannerROS : public nav_core::BaseLocalPlanner
+class TebLocalPlannerROS : public nav_core::BaseLocalPlanner, public mbf_costmap_core::CostmapController
 {
 
 public:
@@ -125,6 +127,36 @@ public:
   bool computeVelocityCommands(geometry_msgs::Twist& cmd_vel);
 
   /**
+    * @brief Given the current position, orientation, and velocity of the robot, compute velocity commands to send to the base.
+    * @remark Extended version for MBF API
+    * @param pose the current pose of the robot.
+    * @param velocity the current velocity of the robot.
+    * @param cmd_vel Will be filled with the velocity command to be passed to the robot base.
+    * @param message Optional more detailed outcome as a string
+    * @return Result code as described on ExePath action result:
+    *         SUCCESS         = 0
+    *         1..9 are reserved as plugin specific non-error results
+    *         FAILURE         = 100   Unspecified failure, only used for old, non-mfb_core based plugins
+    *         CANCELED        = 101
+    *         NO_VALID_CMD    = 102
+    *         PAT_EXCEEDED    = 103
+    *         COLLISION       = 104
+    *         OSCILLATION     = 105
+    *         ROBOT_STUCK     = 106
+    *         MISSED_GOAL     = 107
+    *         MISSED_PATH     = 108
+    *         BLOCKED_PATH    = 109
+    *         INVALID_PATH    = 110
+    *         TF_ERROR        = 111
+    *         NOT_INITIALIZED = 112
+    *         INVALID_PLUGIN  = 113
+    *         INTERNAL_ERROR  = 114
+    *         121..149 are reserved as plugin specific errors
+    */
+  uint32_t computeVelocityCommands(const geometry_msgs::PoseStamped& pose, const geometry_msgs::TwistStamped& velocity,
+                                   geometry_msgs::TwistStamped &cmd_vel, std::string &message);
+
+  /**
     * @brief  Check if the goal pose has been achieved
     * 
     * The actual check is performed in computeVelocityCommands(). 
@@ -132,9 +164,20 @@ public:
     * @return True if achieved, false otherwise
     */
   bool isGoalReached();
-  
-  
-    
+
+  /**
+    * @brief Dummy version to satisfy MBF API
+    */
+  bool isGoalReached(double xy_tolerance, double yaw_tolerance) { return isGoalReached(); };
+
+  /**
+    * @brief Requests the planner to cancel, e.g. if it takes too much time
+    * @remark New on MBF API
+    * @return True if a cancel has been successfully requested, false if not implemented.
+    */
+  bool cancel() { return false; };
+
+
   /** @name Public utility functions/methods */
   //@{
   
@@ -154,7 +197,7 @@ public:
    */
   static RobotFootprintModelPtr getRobotFootprintFromParamServer(const ros::NodeHandle& nh);
   
-    /** 
+  /** 
    * @brief Set the footprint from the given XmlRpcValue.
    * @remarks This method is copied from costmap_2d/footprint.h, since it is not declared public in all ros distros
    * @remarks It is modified in order to return a container of Eigen::Vector2d instead of geometry_msgs::Point

--- a/package.xml
+++ b/package.xml
@@ -39,6 +39,8 @@
   <depend>libg2o</depend>
   <depend>nav_core</depend>
   <depend>nav_msgs</depend>
+  <depend>mbf_costmap_core</depend>
+  <depend>mbf_msgs</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
@@ -48,5 +50,6 @@
 
   <export>
     <nav_core plugin="${prefix}/teb_local_planner_plugin.xml"/>
+    <mbf_costmap_core plugin="${prefix}/teb_local_planner_plugin.xml"/>
   </export>
 </package>

--- a/teb_local_planner_plugin.xml
+++ b/teb_local_planner_plugin.xml
@@ -5,5 +5,10 @@
 			to the base_local_planner of the 2D navigation stack.
 		</description>
 	</class>
+	<class name="teb_local_planner/TebLocalPlannerROS" type="teb_local_planner::TebLocalPlannerROS" base_class_type="mbf_costmap_core::CostmapController">
+		<description>
+			Same plugin implemented MBF CostmapController's extended interface.
+		</description>
+	</class>
 </library>
 


### PR DESCRIPTION
The teb_local_planner plugin can still be used both in move_base and move_base_flex (MBF), but now provides an extended interface when used on MBF. Main drawback is the dependency on _mbf_costmap_core_ and _mbf_msgs_.
We provide the following exit codes:
- SUCCESS
- NOT_INITIALIZED
- INTERNAL_ERROR
- INVALID_PATH
- NO_VALID_CMD

Probably it would make sense to return also OSCILLATION, but I let this for another PR.
Also implementing cancel can make sense, when the controller takes too long to return, e.g. #144
