### PR TITLE
On footprintCost, fail only if footprint is in collision, not outside the map or on unknown space

### DIFF
--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -1197,7 +1197,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
   
   for (int i=0; i <= look_ahead_idx; ++i)
   {           
-    if ( costmap_model->footprintCost(teb().Pose(i).x(), teb().Pose(i).y(), teb().Pose(i).theta(), footprint_spec, inscribed_radius, circumscribed_radius) < 0 )
+    if ( costmap_model->footprintCost(teb().Pose(i).x(), teb().Pose(i).y(), teb().Pose(i).theta(), footprint_spec, inscribed_radius, circumscribed_radius) == -1 )
     {
       if (visualization_)
       {


### PR DESCRIPTION
Actually, this was already done in one of the 2 calls to footprintCost! 

Makes sense after this change on ROS nav: https://github.com/ros-planning/navigation/pull/837