### PR TITLE
Adding the option to shift ahead the target pose used to extract the velocity command

### DIFF
--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -193,9 +193,10 @@ public:
    * @param[out] vx translational velocity [m/s]
    * @param[out] vy strafing velocity which can be nonzero for holonomic robots [m/s]
    * @param[out] omega rotational velocity [rad/s]
+   * @param[in] look_ahead_poses index of the final pose used to compute the velocity command.
    * @return \c true if command is valid, \c false otherwise
    */
-  virtual bool getVelocityCommand(double& vx, double& vy, double& omega) const;
+  virtual bool getVelocityCommand(double& vx, double& vy, double& omega, int look_ahead_poses) const;
 
   /**
    * @brief Access current best trajectory candidate (that relates to the "best" homotopy class).

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -211,9 +211,10 @@ public:
    * @param[out] vx translational velocity [m/s]
    * @param[out] vy strafing velocity which can be nonzero for holonomic robots[m/s] 
    * @param[out] omega rotational velocity [rad/s]
+   * @param[in] look_ahead_poses index of the final pose used to compute the velocity command.
    * @return \c true if command is valid, \c false otherwise
    */
-  virtual bool getVelocityCommand(double& vx, double& vy, double& omega) const;
+  virtual bool getVelocityCommand(double& vx, double& vy, double& omega, int look_ahead_poses) const;
   
   
   /**

--- a/include/teb_local_planner/planner_interface.h
+++ b/include/teb_local_planner/planner_interface.h
@@ -129,9 +129,10 @@ public:
    * @param[out] vx translational velocity [m/s]
    * @param[out] vy strafing velocity which can be nonzero for holonomic robots [m/s] 
    * @param[out] omega rotational velocity [rad/s]
+   * @param[in] look_ahead_poses index of the final pose used to compute the velocity command.
    * @return \c true if command is valid, \c false otherwise
    */
-  virtual bool getVelocityCommand(double& vx, double& vy, double& omega) const = 0;
+  virtual bool getVelocityCommand(double& vx, double& vy, double& omega, int look_ahead_poses) const = 0;
   
   //@}
   

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -84,6 +84,7 @@ public:
     int feasibility_check_no_poses; //!< Specify up to which pose on the predicted plan the feasibility should be checked each sampling interval.
     bool publish_feedback; //!< Publish planner feedback containing the full trajectory and a list of active obstacles (should be enabled only for evaluation or debugging purposes)
     double min_resolution_collision_check_angular; //! Min angular resolution used during the costmap collision check. If not respected, intermediate samples are added. [rad]
+    int control_look_ahead_poses; //! Index of the pose used to extract the velocity command
   } trajectory; //!< Trajectory related parameters
 
   //! Robot related parameters
@@ -246,7 +247,8 @@ public:
     trajectory.feasibility_check_no_poses = 5;
     trajectory.publish_feedback = false;
     trajectory.min_resolution_collision_check_angular = M_PI;
-
+    trajectory.control_look_ahead_poses = 1;
+    
     // Robot
 
     robot.max_vel_x = 0.4;

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -125,7 +125,7 @@ bool HomotopyClassPlanner::plan(const PoseSE2& start, const PoseSE2& goal, const
   return true;
 }
 
-bool HomotopyClassPlanner::getVelocityCommand(double& vx, double& vy, double& omega) const
+bool HomotopyClassPlanner::getVelocityCommand(double& vx, double& vy, double& omega, int look_ahead_poses) const
 {
   TebOptimalPlannerConstPtr best_teb = bestTeb();
   if (!best_teb)
@@ -136,7 +136,7 @@ bool HomotopyClassPlanner::getVelocityCommand(double& vx, double& vy, double& om
     return false;
   }
 
-  return best_teb->getVelocityCommand(vx, vy, omega);
+  return best_teb->getVelocityCommand(vx, vy, omega, look_ahead_poses);
 }
 
 

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -1086,7 +1086,7 @@ void TebOptimalPlanner::extractVelocity(const PoseSE2& pose1, const PoseSE2& pos
   omega = orientdiff/dt;
 }
 
-bool TebOptimalPlanner::getVelocityCommand(double& vx, double& vy, double& omega) const
+bool TebOptimalPlanner::getVelocityCommand(double& vx, double& vy, double& omega, int look_ahead_poses) const
 {
   if (teb_.sizePoses()<2)
   {
@@ -1096,8 +1096,10 @@ bool TebOptimalPlanner::getVelocityCommand(double& vx, double& vy, double& omega
     omega = 0;
     return false;
   }
-  
-  double dt = teb_.TimeDiff(0);
+  look_ahead_poses = std::max(1, std::min(look_ahead_poses, teb_.sizePoses() - 1));
+  double dt = 0.0;
+  for(int counter = 0; counter < look_ahead_poses; ++counter)
+    dt += teb_.TimeDiff(counter);
   if (dt<=0)
   {	
     ROS_ERROR("TebOptimalPlanner::getVelocityCommand() - timediff<=0 is invalid!");
@@ -1108,7 +1110,7 @@ bool TebOptimalPlanner::getVelocityCommand(double& vx, double& vy, double& omega
   }
 	  
   // Get velocity from the first two configurations
-  extractVelocity(teb_.Pose(0), teb_.Pose(1), dt, vx, vy, omega);
+  extractVelocity(teb_.Pose(0), teb_.Pose(look_ahead_poses), dt, vx, vy, omega);
   return true;
 }
 

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -66,6 +66,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("feasibility_check_no_poses", trajectory.feasibility_check_no_poses, trajectory.feasibility_check_no_poses);
   nh.param("publish_feedback", trajectory.publish_feedback, trajectory.publish_feedback);
   nh.param("min_resolution_collision_check_angular", trajectory.min_resolution_collision_check_angular, trajectory.min_resolution_collision_check_angular);
+  nh.param("control_look_ahead_poses", trajectory.control_look_ahead_poses, trajectory.control_look_ahead_poses);
   
   // Robot
   nh.param("max_vel_x", robot.max_vel_x, robot.max_vel_x);

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -383,7 +383,7 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   }
 
   // Get the velocity command for this sampling interval
-  if (!planner_->getVelocityCommand(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z))
+  if (!planner_->getVelocityCommand(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z, cfg_.trajectory.control_look_ahead_poses))
   {
     planner_->clearPlanner();
     ROS_WARN("TebLocalPlannerROS: velocity command invalid. Resetting planner...");


### PR DESCRIPTION
Addresses the issue https://github.com/rst-tu-dortmund/teb_local_planner/issues/92

If the reference dt used to compute the trajectory, and consequently to calculate the velocity commands sent to the base, is small enough to be comparable with the actuation / localization delays of the system, the vehicle might oscillate around the tracked global path.

This could be mitigated increasing the reference dt, but such a solution would also imply a loss of resolution in the trajectory.
Reducing the angular acceleration can also stabilize the system, reducing its "control bandwidth", but has of course a negative impact on the overall performance.

The proposed solution allows the option to shift the reference pose used for the commands generation to the future: this increases the dt used as denominator in the commands generation and at the same time doesn't sacrifice the resolution of the trajectory or the max angular acceleration of the base.

By default, the code doesn't shift the control pose, using the pose of index  1 as reference.
In our experiments, using the pose of index 3 eliminates any oscillation of the robot.
Using a big shift is not recommanded, since this would result in the controller "cutting" part of the trajectory.