### PR TITLE
Fix init with a given plan including a rotation on spot

### DIFF
--- a/include/teb_local_planner/timed_elastic_band.h
+++ b/include/teb_local_planner/timed_elastic_band.h
@@ -417,13 +417,14 @@ public:
    * via the argument \c dt.
    * @param plan vector of geometry_msgs::PoseStamped
    * @param max_vel_x maximum translational velocity used for determining time differences
+   * @param max_vel_theta maximum rotational velocity used for determining time differences
    * @param estimate_orient if \c true, calculate orientation using the straight line distance vector between consecutive poses
    *                        (only copy start and goal orientation; recommended if no orientation data is available).
    * @param min_samples Minimum number of samples that should be initialized at least
    * @param guess_backwards_motion Allow the initialization of backwards oriented trajectories if the goal heading is pointing behind the robot (this parameter is used only if \c estimate_orient is enabled.
    * @return true if everything was fine, false otherwise
    */
-  bool initTrajectoryToGoal(const std::vector<geometry_msgs::PoseStamped>& plan, double max_vel_x, bool estimate_orient=false, int min_samples = 3, bool guess_backwards_motion = false);
+  bool initTrajectoryToGoal(const std::vector<geometry_msgs::PoseStamped>& plan, double max_vel_x, double max_vel_theta, bool estimate_orient=false, int min_samples = 3, bool guess_backwards_motion = false);
 
 
   ROS_DEPRECATED bool initTEBtoGoal(const PoseSE2& start, const PoseSE2& goal, double diststep=0, double timestep=1, int min_samples = 3, bool guess_backwards_motion = false)
@@ -446,7 +447,7 @@ public:
   {
     ROS_WARN_ONCE("initTEBtoGoal is deprecated and has been replaced by initTrajectoryToGoal. The signature has changed: dt has been replaced by max_vel_x. \
                    this deprecated method sets max_vel = 1. Please update your code.");
-    return initTrajectoryToGoal(plan, dt, estimate_orient, min_samples, guess_backwards_motion);
+    return initTrajectoryToGoal(plan, 1.0, 1.0, estimate_orient, min_samples, guess_backwards_motion);
   }
 
   

--- a/include/teb_local_planner/timed_elastic_band.hpp
+++ b/include/teb_local_planner/timed_elastic_band.hpp
@@ -108,7 +108,7 @@ bool TimedElasticBand::initTrajectoryToGoal(BidirIter path_start, BidirIter path
             }
             else timestep = timestep_vel;
             
-            if (timestep<0) timestep=0.2; // TODO: this is an assumption
+            if (timestep<=0) timestep=0.2; // TODO: this is an assumption
             
             double yaw = atan2(diff_last[1],diff_last[0]);
             if (backwards)
@@ -131,7 +131,7 @@ bool TimedElasticBand::initTrajectoryToGoal(BidirIter path_start, BidirIter path
             }
             else timestep = timestep_vel;
             
-            if (timestep<0) timestep=0.2; // TODO: this is an assumption
+            if (timestep<=0) timestep=0.2; // TODO: this is an assumption
             
             yaw = atan2(diff_last[1],diff_last[0]); // TODO redundant right now, not yet finished
             if (backwards)

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -381,7 +381,7 @@ TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const std::vector<ge
     return TebOptimalPlannerPtr();
   TebOptimalPlannerPtr candidate = TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, robot_model_, visualization_));
 
-  candidate->teb().initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x,
+  candidate->teb().initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, cfg_->robot.max_vel_theta,
     cfg_->trajectory.global_plan_overwrite_orientation, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
 
   if (start_velocity)

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -238,9 +238,9 @@ bool TebOptimalPlanner::plan(const std::vector<geometry_msgs::PoseStamped>& init
   ROS_ASSERT_MSG(initialized_, "Call initialize() first.");
   if (!teb_.isInit())
   {
-    // init trajectory
-    teb_.initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, cfg_->trajectory.global_plan_overwrite_orientation, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
-  } 
+    teb_.initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, cfg_->robot.max_vel_theta, cfg_->trajectory.global_plan_overwrite_orientation,
+      cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
+  }
   else // warm start
   {
     PoseSE2 start_(initial_plan.front().pose);
@@ -251,7 +251,8 @@ bool TebOptimalPlanner::plan(const std::vector<geometry_msgs::PoseStamped>& init
     {
       ROS_DEBUG("New goal: distance to existing goal is higher than the specified threshold. Reinitalizing trajectories.");
       teb_.clearTimedElasticBand();
-      teb_.initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, true, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
+      teb_.initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, cfg_->robot.max_vel_theta, true,
+        cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
     }
   }
   if (start_vel)

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -251,7 +251,7 @@ bool TebOptimalPlanner::plan(const std::vector<geometry_msgs::PoseStamped>& init
     {
       ROS_DEBUG("New goal: distance to existing goal is higher than the specified threshold. Reinitalizing trajectories.");
       teb_.clearTimedElasticBand();
-      teb_.initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, cfg_->robot.max_vel_theta, true,
+      teb_.initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, cfg_->robot.max_vel_theta, cfg_->trajectory.global_plan_overwrite_orientation,
         cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
     }
   }


### PR DESCRIPTION
When a TEB is initialized from a plan with turn-on-spot rotations, the TEB adds a VertexTimeDiff with dt=0. Subsequently, this leads to division by zero in, for example, EdgeVelocity.
The division by zero causes the optimization to fail completely due to the NaN in the error vector.
A g2o-file would look like this:
```
VERTEX_POSE 128 10.0959 9.54506 -0.838493
VERTEX_TIMEDIFF 129 0
VERTEX_POSE 130 10.0959 9.54506 -0.981748
```
In the above example Vertex 129 would lead to the failing optimization.

Our fix is to also consider rotation on spot for computing the initial dt of the VertexTimeDiff.
Furthermore, we add an assertion in TimedElasticBand::addTimeDiff to catch this early.