### PR TITLE
Limiting the control look-ahead pose to the first that execeeds the expected look-ahead time

### DIFF
--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -1100,7 +1100,14 @@ bool TebOptimalPlanner::getVelocityCommand(double& vx, double& vy, double& omega
   look_ahead_poses = std::max(1, std::min(look_ahead_poses, teb_.sizePoses() - 1));
   double dt = 0.0;
   for(int counter = 0; counter < look_ahead_poses; ++counter)
+  {
     dt += teb_.TimeDiff(counter);
+    if(dt >= cfg_->trajectory.dt_ref * look_ahead_poses)  // TODO: change to look-ahead time? Refine trajectory?
+    {
+        look_ahead_poses = counter + 1;
+        break;
+    }
+  }
   if (dt<=0)
   {	
     ROS_ERROR("TebOptimalPlanner::getVelocityCommand() - timediff<=0 is invalid!");


### PR DESCRIPTION
Currently the user has the option shift the pose used for the commands generation in the future in order to increase the d_t used as denominator in the commands generation.
However, if the trajectory's optimization fails to enforce the reference d_t between its poses, the resulting "control d_t" might become much bigger than the expected one (this sometimes occurs if the platform gets very close to obstacles).

This small change stops the look-ahead process at the first pose that exceeds the expected "control d_t" = look_ahead_poses * reference_dt.