### PR TITLE
Setting control frequency parameter as double instead of int to solve…

### DIFF
--- a/teb_local_planner/launch/teb_params.yaml
+++ b/teb_local_planner/launch/teb_params.yaml
@@ -72,7 +72,7 @@ bt_navigator_rclcpp_node:
 controller_server:
   ros__parameters:
     use_sim_time: True
-    controller_frequency: 20
+    controller_frequency: 20.0
     controller_plugin_types: ["teb_local_planner::TebLocalPlannerROS"]
     controller_plugin_ids: ["DynamicFollowPath"]
     DynamicFollowPath.footprint_model.type: circular


### PR DESCRIPTION
Hi, while trying to execute

ros2 launch teb_local_planner teb_tb3_simulation_launch.py

I got the following error

[controller_server-8] [INFO] [controller_server]: Creating controller server
[controller_server-8] terminate called after throwing an instance of 'rclcpp::ParameterTypeException'
[controller_server-8]   what():  expected [double] got [integer]
[ERROR] [controller_server-8]: process has died [pid 13148, exit code -6, cmd '/opt/ros/eloquent/lib/nav2_controller/controller_server --ros-args --params-file /tmp/tmpbyu6khb5 

which I tracked down to the control_frequency parameter; hence the change.