### PR TITLE
Reserve the size of the relevant obstacles vector to avoid memory allocation

### DIFF
--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -432,6 +432,9 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
   information_inflated(0,0) = cfg_->optim.weight_obstacle * weight_multiplier;
   information_inflated(1,1) = cfg_->optim.weight_inflation;
   information_inflated(0,1) = information_inflated(1,0) = 0;
+
+  std::vector<Obstacle*> relevant_obstacles;
+  relevant_obstacles.reserve(obstacles_->size());
     
   // iterate all teb points (skip first and last)
   for (int i=1; i < teb_.sizePoses()-1; ++i)
@@ -441,7 +444,7 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
       Obstacle* left_obstacle = nullptr;
       Obstacle* right_obstacle = nullptr;
       
-      std::vector<Obstacle*> relevant_obstacles;
+      relevant_obstacles.clear();
       
       const Eigen::Vector2d pose_orient = teb_.Pose(i).orientationUnitVec();
       


### PR DESCRIPTION
This change becomes more significant as the amount of obstacles increases. If the size is not reserved, in gcc, the capacity starts at zero, increases to one after the first `push_back`, and then doubles every time a `push_back` would cause the number of elements to exceed the current capacity. When this happens, more memory is allocated for the vector.

I didn't benchmark to measure the scenarios where this PR is more beneficial.