### PR TITLE
New type of velocity constraint

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -189,7 +189,21 @@ grp_obstacles.add("costmap_obstacles_behind_robot_dist",   double_t,   0,
 grp_obstacles.add("obstacle_poses_affected",    int_t,    0, 
 	"The obstacle position is attached to the closest pose on the trajectory to reduce computational effort, but take a number of neighbors into account as well", 
 	30, 0, 200)
-	
+
+# Obstacle - Velocity ratio parameters
+grp_obstacles_velocity_limit = grp_obstacles.add_group("Reduce velocity near obstacles")
+
+grp_obstacles_velocity_limit.add("obstacle_proximity_ratio_max_vel", double_t, 0,
+        "Ratio of the maximum velocities used as an upper bound when reducing the speed due to the proximity to a static obstacles",
+        1, 0, 1)
+
+grp_obstacles_velocity_limit.add("obstacle_proximity_lower_bound", double_t, 0,
+        "Distance to a static obstacle for which the velocity should be lower",
+        0, 0, 10)
+
+grp_obstacles_velocity_limit.add("obstacle_proximity_upper_bound", double_t, 0,
+        "Distance to a static obstacle for which the velocity should be higher",
+        0.5, 0, 10)
 
 # Optimization
 grp_optimization = gen.add_group("Optimization", type="tab")    
@@ -273,6 +287,10 @@ grp_optimization.add("weight_dynamic_obstacle", double_t, 0,
 grp_optimization.add("weight_dynamic_obstacle_inflation", double_t, 0,
         "Optimization weight for the inflation penalty of dynamic obstacles (should be small)",
         0.1, 0, 10)
+
+grp_optimization.add("weight_obstacle_velocity_ratio", double_t, 0,
+        "Optimization weight for satisfying a maximum allowed velocity with respect to the distance to a static obstacle",
+        0, 0, 1000)
 
 grp_optimization.add("weight_viapoint", double_t, 0, 
   "Optimization weight for minimizing the distance to via-points", 

--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -194,7 +194,7 @@ grp_obstacles.add("obstacle_poses_affected",    int_t,    0,
 grp_obstacles_velocity_limit = grp_obstacles.add_group("Reduce velocity near obstacles")
 
 grp_obstacles_velocity_limit.add("obstacle_proximity_ratio_max_vel", double_t, 0,
-        "Ratio of the maximum velocities used as an upper bound when reducing the speed due to the proximity to a static obstacles",
+        "Ratio of the maximum velocities used as an upper bound when reducing the speed due to the proximity to static obstacles",
         1, 0, 1)
 
 grp_obstacles_velocity_limit.add("obstacle_proximity_lower_bound", double_t, 0,
@@ -288,7 +288,7 @@ grp_optimization.add("weight_dynamic_obstacle_inflation", double_t, 0,
         "Optimization weight for the inflation penalty of dynamic obstacles (should be small)",
         0.1, 0, 10)
 
-grp_optimization.add("weight_obstacle_velocity_ratio", double_t, 0,
+grp_optimization.add("weight_velocity_obstacle_ratio", double_t, 0,
         "Optimization weight for satisfying a maximum allowed velocity with respect to the distance to a static obstacle",
         0, 0, 1000)
 

--- a/include/teb_local_planner/g2o_types/edge_velocity_obstacle_ratio.h
+++ b/include/teb_local_planner/g2o_types/edge_velocity_obstacle_ratio.h
@@ -1,0 +1,123 @@
+#pragma once
+
+
+#include <teb_local_planner/optimal_planner.h>
+
+
+namespace teb_local_planner
+{
+
+
+/**
+ * @class EdgeVelocityObstacleRatio
+ * @brief Edge defining the cost function for keeping a minimum distance from obstacles.
+ *
+ * The edge depends on a single vertex \f$ \mathbf{s}_i \f$ and minimizes: \n
+ * \f$ \min \textrm{penaltyBelow}( dist2point ) \cdot weight \f$. \n
+ * \e dist2point denotes the minimum distance to the point obstacle. \n
+ * \e weight can be set using setInformation(). \n
+ * \e penaltyBelow denotes the penalty function, see penaltyBoundFromBelow() \n
+ * @see TebOptimalPlanner::AddEdgesObstacles, TebOptimalPlanner::EdgeInflatedObstacle
+ * @remarks Do not forget to call setTebConfig() and setObstacle()
+ */
+class EdgeVelocityObstacleRatio : public BaseTebMultiEdge<2, const Obstacle*>
+{
+public:
+
+  /**
+   * @brief Construct edge.
+   */
+  EdgeVelocityObstacleRatio() :
+    robot_model_(nullptr)
+  {
+    // The three vertices are two poses and one time difference
+    this->resize(3); // Since we derive from a g2o::BaseMultiEdge, set the desired number of vertices
+  }
+
+  /**
+   * @brief Actual cost function
+   */
+  void computeError()
+  {
+    ROS_ASSERT_MSG(cfg_ && _measurement && robot_model_, "You must call setTebConfig(), setObstacle() and setRobotModel() on EdgeVelocityObstacleRatio()");
+    const VertexPose* conf1 = static_cast<const VertexPose*>(_vertices[0]);
+    const VertexPose* conf2 = static_cast<const VertexPose*>(_vertices[1]);
+    const VertexTimeDiff* deltaT = static_cast<const VertexTimeDiff*>(_vertices[2]);
+
+    const Eigen::Vector2d deltaS = conf2->estimate().position() - conf1->estimate().position();
+
+    double dist = deltaS.norm();
+    const double angle_diff = g2o::normalize_theta(conf2->theta() - conf1->theta());
+    if (cfg_->trajectory.exact_arc_length && angle_diff != 0)
+    {
+        double radius =  dist/(2*sin(angle_diff/2));
+        dist = fabs( angle_diff * radius ); // actual arg length!
+    }
+    double vel = dist / deltaT->estimate();
+
+    vel *= fast_sigmoid( 100 * (deltaS.x()*cos(conf1->theta()) + deltaS.y()*sin(conf1->theta())) ); // consider direction
+
+    const double omega = angle_diff / deltaT->estimate();
+
+    double dist_to_obstacle = robot_model_->calculateDistance(conf1->pose(), _measurement);
+
+    double ratio;
+    if (dist_to_obstacle < cfg_->obstacles.obstacle_proximity_lower_bound)
+      ratio = 0;
+    else if (dist_to_obstacle > cfg_->obstacles.obstacle_proximity_upper_bound)
+      ratio = 1;
+    else
+      ratio = (dist_to_obstacle - cfg_->obstacles.obstacle_proximity_lower_bound) /
+      (cfg_->obstacles.obstacle_proximity_upper_bound - cfg_->obstacles.obstacle_proximity_lower_bound);
+    ratio *= cfg_->obstacles.obstacle_proximity_ratio_max_vel;
+
+    const double max_vel_fwd = ratio * cfg_->robot.max_vel_x;
+    const double max_omega = ratio * cfg_->robot.max_vel_theta;
+    _error[0] = penaltyBoundToInterval(vel, max_vel_fwd, 0);
+    _error[1] = penaltyBoundToInterval(omega, max_omega, 0);
+
+    ROS_ASSERT_MSG(std::isfinite(_error[0]) || std::isfinite(_error[1]), "EdgeVelocityObstacleRatio::computeError() _error[0]=%f , _error[1]=%f\n",_error[0],_error[1]);
+  }
+
+  /**
+   * @brief Set pointer to associated obstacle for the underlying cost function
+   * @param obstacle 2D position vector containing the position of the obstacle
+   */
+  void setObstacle(const Obstacle* obstacle)
+  {
+    _measurement = obstacle;
+  }
+
+  /**
+   * @brief Set pointer to the robot model
+   * @param robot_model Robot model required for distance calculation
+   */
+  void setRobotModel(const BaseRobotFootprintModel* robot_model)
+  {
+    robot_model_ = robot_model;
+  }
+
+  /**
+   * @brief Set all parameters at once
+   * @param cfg TebConfig class
+   * @param robot_model Robot model required for distance calculation
+   * @param obstacle 2D position vector containing the position of the obstacle
+   */
+  void setParameters(const TebConfig& cfg, const BaseRobotFootprintModel* robot_model, const Obstacle* obstacle)
+  {
+    cfg_ = &cfg;
+    robot_model_ = robot_model;
+    _measurement = obstacle;
+  }
+
+protected:
+
+  const BaseRobotFootprintModel* robot_model_; //!< Store pointer to robot_model
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+};
+
+
+} // end namespace

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -652,6 +652,13 @@ protected:
    * @see optimizeGraph
    */
   void AddEdgesPreferRotDir(); 
+
+  /**
+   * @brief Add all edges (local cost function) for reducing the velocity of a vertex due to its associated obstacles
+   * @see buildGraph
+   * @see optimizeGraph
+   */
+  void AddEdgesVelocityObstacleRatio();
   
   //@}
   
@@ -667,6 +674,7 @@ protected:
   const TebConfig* cfg_; //!< Config class that stores and manages all related parameters
   ObstContainer* obstacles_; //!< Store obstacles that are relevant for planning
   const ViaPointContainer* via_points_; //!< Store via points for planning
+  std::vector<ObstContainer> obstacles_per_vertex_; //!< Store the obstacles associated with the n-1 initial vertices
   
   double cost_; //!< Store cost value of the current hyper-graph
   RotType prefer_rotdir_; //!< Store whether to prefer a specific initial rotation in optimization (might be activated in case the robot oscillates)

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -59,17 +59,6 @@
 #include <g2o/solvers/csparse/linear_solver_csparse.h>
 #include <g2o/solvers/cholmod/linear_solver_cholmod.h>
 
-// g2o custom edges and vertices for the TEB planner
-#include <teb_local_planner/g2o_types/edge_velocity.h>
-#include <teb_local_planner/g2o_types/edge_acceleration.h>
-#include <teb_local_planner/g2o_types/edge_kinematics.h>
-#include <teb_local_planner/g2o_types/edge_time_optimal.h>
-#include <teb_local_planner/g2o_types/edge_shortest_path.h>
-#include <teb_local_planner/g2o_types/edge_obstacle.h>
-#include <teb_local_planner/g2o_types/edge_dynamic_obstacle.h>
-#include <teb_local_planner/g2o_types/edge_via_point.h>
-#include <teb_local_planner/g2o_types/edge_prefer_rotdir.h>
-
 // messages
 #include <nav_msgs/Path.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -612,7 +601,6 @@ protected:
   
   /**
    * @brief Add all edges (local cost functions) related to keeping a distance from static obstacles (legacy association strategy)
-   * @warning do not combine with AddEdgesInflatedObstacles
    * @see EdgeObstacle
    * @see buildGraph
    * @see optimizeGraph

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -161,7 +161,7 @@ public:
     double weight_inflation; //!< Optimization weight for the inflation penalty (should be small)
     double weight_dynamic_obstacle; //!< Optimization weight for satisfying a minimum separation from dynamic obstacles
     double weight_dynamic_obstacle_inflation; //!< Optimization weight for the inflation penalty of dynamic obstacles (should be small)
-    double weight_obstacle_velocity_ratio; //!< Optimization weight for satisfying a maximum allowed velocity with respect to the distance to a static obstacle
+    double weight_velocity_obstacle_ratio; //!< Optimization weight for satisfying a maximum allowed velocity with respect to the distance to a static obstacle
     double weight_viapoint; //!< Optimization weight for minimizing the distance to via-points
     double weight_prefer_rotdir; //!< Optimization weight for preferring a specific turning direction (-> currently only activated if an oscillation is detected, see 'oscillation_recovery'
 
@@ -317,7 +317,7 @@ public:
     optim.weight_inflation = 0.1;
     optim.weight_dynamic_obstacle = 50;
     optim.weight_dynamic_obstacle_inflation = 0.1;
-    optim.weight_obstacle_velocity_ratio = 0;
+    optim.weight_velocity_obstacle_ratio = 0;
     optim.weight_viapoint = 1;
     optim.weight_prefer_rotdir = 50;
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -129,6 +129,9 @@ public:
     std::string costmap_converter_plugin; //!< Define a plugin name of the costmap_converter package (costmap cells are converted to points/lines/polygons)
     bool costmap_converter_spin_thread; //!< If \c true, the costmap converter invokes its callback queue in a different thread
     int costmap_converter_rate; //!< The rate that defines how often the costmap_converter plugin processes the current costmap (the value should not be much higher than the costmap update rate)
+    double obstacle_proximity_ratio_max_vel; //!< Ratio of the maximum velocities used as an upper bound when reducing the speed due to the proximity to a static obstacles
+    double obstacle_proximity_lower_bound; //!< Distance to a static obstacle for which the velocity should be lower
+    double obstacle_proximity_upper_bound; //!< Distance to a static obstacle for which the velocity should be higher
   } obstacles; //!< Obstacle related parameters
 
 
@@ -158,6 +161,7 @@ public:
     double weight_inflation; //!< Optimization weight for the inflation penalty (should be small)
     double weight_dynamic_obstacle; //!< Optimization weight for satisfying a minimum separation from dynamic obstacles
     double weight_dynamic_obstacle_inflation; //!< Optimization weight for the inflation penalty of dynamic obstacles (should be small)
+    double weight_obstacle_velocity_ratio; //!< Optimization weight for satisfying a maximum allowed velocity with respect to the distance to a static obstacle
     double weight_viapoint; //!< Optimization weight for minimizing the distance to via-points
     double weight_prefer_rotdir; //!< Optimization weight for preferring a specific turning direction (-> currently only activated if an oscillation is detected, see 'oscillation_recovery'
 
@@ -287,6 +291,9 @@ public:
     obstacles.costmap_converter_plugin = "";
     obstacles.costmap_converter_spin_thread = true;
     obstacles.costmap_converter_rate = 5;
+    obstacles.obstacle_proximity_ratio_max_vel = 1;
+    obstacles.obstacle_proximity_lower_bound = 0;
+    obstacles.obstacle_proximity_upper_bound = 0.5;
 
     // Optimization
 
@@ -310,6 +317,7 @@ public:
     optim.weight_inflation = 0.1;
     optim.weight_dynamic_obstacle = 50;
     optim.weight_dynamic_obstacle_inflation = 0.1;
+    optim.weight_obstacle_velocity_ratio = 0;
     optim.weight_viapoint = 1;
     optim.weight_prefer_rotdir = 50;
 

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -358,7 +358,7 @@ bool TebOptimalPlanner::buildGraph(double weight_multiplier)
 
   AddEdgesPreferRotDir();
 
-  if (cfg_->optim.weight_obstacle_velocity_ratio > 0)
+  if (cfg_->optim.weight_velocity_obstacle_ratio > 0)
     AddEdgesVelocityObstacleRatio();
     
   return true;  
@@ -473,7 +473,7 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
   };
     
   // iterate all teb points, skipping the last and, if the EdgeVelocityObstacleRatio edges should not be created, the first one too
-  const int first_vertex = cfg_->optim.weight_obstacle_velocity_ratio == 0 ? 1 : 0;
+  const int first_vertex = cfg_->optim.weight_velocity_obstacle_ratio == 0 ? 1 : 0;
   for (int i = first_vertex; i < teb_.sizePoses() - 1; ++i)
   {    
       double left_min_dist = std::numeric_limits<double>::max();
@@ -993,8 +993,8 @@ void TebOptimalPlanner::AddEdgesPreferRotDir()
 void TebOptimalPlanner::AddEdgesVelocityObstacleRatio()
 {
   Eigen::Matrix<double,2,2> information;
-  information(0,0) = cfg_->optim.weight_obstacle_velocity_ratio;
-  information(1,1) = cfg_->optim.weight_obstacle_velocity_ratio;
+  information(0,0) = cfg_->optim.weight_velocity_obstacle_ratio;
+  information(1,1) = cfg_->optim.weight_velocity_obstacle_ratio;
   information(0,1) = information(1,0) = 0;
 
   auto iter_obstacle = obstacles_per_vertex_.begin();

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -446,6 +446,25 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
 
   std::vector<Obstacle*> relevant_obstacles;
   relevant_obstacles.reserve(obstacles_->size());
+
+  auto create_edge = [inflated, &information, &information_inflated, this] (int index, const Obstacle* obstacle) {
+    if (inflated)
+    {
+      EdgeInflatedObstacle* dist_bandpt_obst = new EdgeInflatedObstacle;
+      dist_bandpt_obst->setVertex(0,teb_.PoseVertex(index));
+      dist_bandpt_obst->setInformation(information_inflated);
+      dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), obstacle);
+      optimizer_->addEdge(dist_bandpt_obst);
+    }
+    else
+    {
+      EdgeObstacle* dist_bandpt_obst = new EdgeObstacle;
+      dist_bandpt_obst->setVertex(0,teb_.PoseVertex(index));
+      dist_bandpt_obst->setInformation(information);
+      dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), obstacle);
+      optimizer_->addEdge(dist_bandpt_obst);
+    };
+  };
     
   // iterate all teb points (skip first and last)
   for (int i=1; i < teb_.sizePoses()-1; ++i)
@@ -500,66 +519,12 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
       
       // create obstacle edges
       if (left_obstacle)
-      {
-            if (inflated)
-            {
-                EdgeInflatedObstacle* dist_bandpt_obst = new EdgeInflatedObstacle;
-                dist_bandpt_obst->setVertex(0,teb_.PoseVertex(i));
-                dist_bandpt_obst->setInformation(information_inflated);
-                dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), left_obstacle);
-                optimizer_->addEdge(dist_bandpt_obst);
-            }
-            else
-            {
-                EdgeObstacle* dist_bandpt_obst = new EdgeObstacle;
-                dist_bandpt_obst->setVertex(0,teb_.PoseVertex(i));
-                dist_bandpt_obst->setInformation(information);
-                dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), left_obstacle);
-                optimizer_->addEdge(dist_bandpt_obst);
-            }
-      }
-      
+        create_edge(i, left_obstacle);
       if (right_obstacle)
-      {
-            if (inflated)
-            {
-                EdgeInflatedObstacle* dist_bandpt_obst = new EdgeInflatedObstacle;
-                dist_bandpt_obst->setVertex(0,teb_.PoseVertex(i));
-                dist_bandpt_obst->setInformation(information_inflated);
-                dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), right_obstacle);
-                optimizer_->addEdge(dist_bandpt_obst);
-            }
-            else
-            {
-                EdgeObstacle* dist_bandpt_obst = new EdgeObstacle;
-                dist_bandpt_obst->setVertex(0,teb_.PoseVertex(i));
-                dist_bandpt_obst->setInformation(information);
-                dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), right_obstacle);
-                optimizer_->addEdge(dist_bandpt_obst);
-            }   
-      }
-      
-      for (const Obstacle* obst : relevant_obstacles)
-      {
-            if (inflated)
-            {
-                EdgeInflatedObstacle* dist_bandpt_obst = new EdgeInflatedObstacle;
-                dist_bandpt_obst->setVertex(0,teb_.PoseVertex(i));
-                dist_bandpt_obst->setInformation(information_inflated);
-                dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), obst);
-                optimizer_->addEdge(dist_bandpt_obst);
-            }
-            else
-            {
-                EdgeObstacle* dist_bandpt_obst = new EdgeObstacle;
-                dist_bandpt_obst->setVertex(0,teb_.PoseVertex(i));
-                dist_bandpt_obst->setInformation(information);
-                dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), obst);
-                optimizer_->addEdge(dist_bandpt_obst);
-            }   
-      }
-  }  
-        
+        create_edge(i, right_obstacle);
+      for (const ObstaclePtr obst : *iter_obstacle)
+        create_edge(i, obst.get());
+  }
 }
 
 

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -37,7 +37,18 @@
  *********************************************************************/
 
 #include <teb_local_planner/optimal_planner.h>
-#include <map>
+
+// g2o custom edges and vertices for the TEB planner
+#include <teb_local_planner/g2o_types/edge_velocity.h>
+#include <teb_local_planner/g2o_types/edge_acceleration.h>
+#include <teb_local_planner/g2o_types/edge_kinematics.h>
+#include <teb_local_planner/g2o_types/edge_time_optimal.h>
+#include <teb_local_planner/g2o_types/edge_shortest_path.h>
+#include <teb_local_planner/g2o_types/edge_obstacle.h>
+#include <teb_local_planner/g2o_types/edge_dynamic_obstacle.h>
+#include <teb_local_planner/g2o_types/edge_via_point.h>
+#include <teb_local_planner/g2o_types/edge_prefer_rotdir.h>
+
 #include <memory>
 #include <limits>
 

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -126,7 +126,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("weight_inflation", optim.weight_inflation, optim.weight_inflation);
   nh.param("weight_dynamic_obstacle", optim.weight_dynamic_obstacle, optim.weight_dynamic_obstacle);    
   nh.param("weight_dynamic_obstacle_inflation", optim.weight_dynamic_obstacle_inflation, optim.weight_dynamic_obstacle_inflation);
-  nh.param("weight_obstacle_velocity_ratio", optim.weight_obstacle_velocity_ratio, optim.weight_obstacle_velocity_ratio);
+  nh.param("weight_velocity_obstacle_ratio", optim.weight_velocity_obstacle_ratio, optim.weight_velocity_obstacle_ratio);
   nh.param("weight_viapoint", optim.weight_viapoint, optim.weight_viapoint);
   nh.param("weight_prefer_rotdir", optim.weight_prefer_rotdir, optim.weight_prefer_rotdir);
   nh.param("weight_adapt_factor", optim.weight_adapt_factor, optim.weight_adapt_factor);
@@ -243,7 +243,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   optim.weight_inflation = cfg.weight_inflation;
   optim.weight_dynamic_obstacle = cfg.weight_dynamic_obstacle;
   optim.weight_dynamic_obstacle_inflation = cfg.weight_dynamic_obstacle_inflation;
-  optim.weight_obstacle_velocity_ratio = cfg.weight_obstacle_velocity_ratio;
+  optim.weight_velocity_obstacle_ratio = cfg.weight_velocity_obstacle_ratio;
   optim.weight_viapoint = cfg.weight_viapoint;
   optim.weight_adapt_factor = cfg.weight_adapt_factor;
   optim.obstacle_cost_exponent = cfg.obstacle_cost_exponent;

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -101,6 +101,9 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("obstacle_association_cutoff_factor", obstacles.obstacle_association_cutoff_factor, obstacles.obstacle_association_cutoff_factor);
   nh.param("costmap_converter_plugin", obstacles.costmap_converter_plugin, obstacles.costmap_converter_plugin);
   nh.param("costmap_converter_spin_thread", obstacles.costmap_converter_spin_thread, obstacles.costmap_converter_spin_thread);
+  nh.param("obstacle_proximity_ratio_max_vel",  obstacles.obstacle_proximity_ratio_max_vel, obstacles.obstacle_proximity_ratio_max_vel);
+  nh.param("obstacle_proximity_lower_bound", obstacles.obstacle_proximity_lower_bound, obstacles.obstacle_proximity_lower_bound);
+  nh.param("obstacle_proximity_upper_bound", obstacles.obstacle_proximity_upper_bound, obstacles.obstacle_proximity_upper_bound);
   
   // Optimization
   nh.param("no_inner_iterations", optim.no_inner_iterations, optim.no_inner_iterations);
@@ -123,6 +126,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("weight_inflation", optim.weight_inflation, optim.weight_inflation);
   nh.param("weight_dynamic_obstacle", optim.weight_dynamic_obstacle, optim.weight_dynamic_obstacle);    
   nh.param("weight_dynamic_obstacle_inflation", optim.weight_dynamic_obstacle_inflation, optim.weight_dynamic_obstacle_inflation);
+  nh.param("weight_obstacle_velocity_ratio", optim.weight_obstacle_velocity_ratio, optim.weight_obstacle_velocity_ratio);
   nh.param("weight_viapoint", optim.weight_viapoint, optim.weight_viapoint);
   nh.param("weight_prefer_rotdir", optim.weight_prefer_rotdir, optim.weight_prefer_rotdir);
   nh.param("weight_adapt_factor", optim.weight_adapt_factor, optim.weight_adapt_factor);
@@ -214,7 +218,9 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   obstacles.obstacle_association_cutoff_factor = cfg.obstacle_association_cutoff_factor;
   obstacles.costmap_obstacles_behind_robot_dist = cfg.costmap_obstacles_behind_robot_dist;
   obstacles.obstacle_poses_affected = cfg.obstacle_poses_affected;
-
+  obstacles.obstacle_proximity_ratio_max_vel = cfg.obstacle_proximity_ratio_max_vel;
+  obstacles.obstacle_proximity_lower_bound = cfg.obstacle_proximity_lower_bound;
+  obstacles.obstacle_proximity_upper_bound = cfg.obstacle_proximity_upper_bound;
   
   // Optimization
   optim.no_inner_iterations = cfg.no_inner_iterations;
@@ -237,6 +243,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   optim.weight_inflation = cfg.weight_inflation;
   optim.weight_dynamic_obstacle = cfg.weight_dynamic_obstacle;
   optim.weight_dynamic_obstacle_inflation = cfg.weight_dynamic_obstacle_inflation;
+  optim.weight_obstacle_velocity_ratio = cfg.weight_obstacle_velocity_ratio;
   optim.weight_viapoint = cfg.weight_viapoint;
   optim.weight_adapt_factor = cfg.weight_adapt_factor;
   optim.obstacle_cost_exponent = cfg.obstacle_cost_exponent;


### PR DESCRIPTION
I know this is quite a change to the planner, but I do believe it might benefit some users; besides, it is optional.

## Why
In the application I work on, the robot must maintain a minimum distance from obstacles, which increase as the robot drives faster, to ensure a given level o safety.

## Previous Attempts
We did try to tune TEB to reach this goal. As expected, it worked very well in most scenarios. However, we had problems tuning for (1) going through doors and (2) driving through corridors.

1. Doors - depending on the path taken to reach the door, the robot would try to cross it preferring one side over the other, either (1.1) making TEB give up to avoid a possible collision (we use a footprint with 1cm padding around the robot and, naturally, we are subject to sensor noise) or (1.2) making our safety system stop the robot.
2. Corridors - depending on several factors (sensor noise, temporary localization drift due to odometry errors, final goal position, ...) I could not find a suitable configuration that could consistently force the robot to drive along the middle of the corridor, without deteriorating the optimization performance in other scenarios.

## Implementation
To address the above-mentioned behaviors, I created another velocity constraint (actually, I still don't know if it is better to treat it as a constraint or as an objective). The idea is to explicitly penalize driving fast close to obstacles, which is achieved by reducing the velocity bounds as a function of the distance to an obstacle.

### Parameters
`weight_velocity_obstacle_ratio` weight for the new constraint
`obstacle_proximity_ratio_max_vel` ratio of the maximum velocities used as an upper bound when reducing the speed due to the proximity to static obstacles
`obstacle_proximity_lower_bound` distance to a static obstacle for which the velocity should be lower
`obstacle_proximity_upper_bound` distance to a static obstacle for which the velocity should be higher

### Formula
The new upper bound, as a function of the distance to an obstacle, is computed as (pseudocode):
```c++
d_max = obstacle_proximity_upper_bound;
d_min = obstacle_proximity_lower_bound;
ratio_distance = (distance - d_min) / (d_max - d_min);
ratio_distance = min( max(ratio_distance, 0), 1 );
ratio = weight_velocity_obstacle_ratio * ratio_distance;
vel_upper_bound = vel_upper_bound * ratio;
```
Then, this is used in an error function identical to the one used for `EdgeVelocity` edges.

### Example
Sample of a plan with (mostly) the default configuration.
```yaml
max_number_classes: 1
min_obstacle_dist: 1.0
```
![plan before](https://user-images.githubusercontent.com/5129986/83349692-2b1bea80-a337-11ea-8776-5feb9700c0ca.png)

Sample of a plan using the proposed velocity constraint.
```yaml
max_number_classes: 1
min_obstacle_dist: 1.0
weight_velocity_obstacle_ratio: 10.0
obstacle_proximity_ratio_max_vel: 0.8
obstacle_proximity_lower_bound: 0.0
obstacle_proximity_upper_bound: 1.5
```
![plan after](https://user-images.githubusercontent.com/5129986/83349787-bf864d00-a337-11ea-885b-41e633fce98d.png)


## Relation to Other PR
PR #209 also helps avoid the door problem when it is caused by the robot drifting away from TEBs optimal plan.