### PR TITLE
Initialize Visualization after Planner to avoid segfault [ros2-master]

### DIFF
--- a/teb_local_planner/include/teb_local_planner/homotopy_class_planner.h
+++ b/teb_local_planner/include/teb_local_planner/homotopy_class_planner.h
@@ -251,7 +251,7 @@ public:
    * @param visualization shared pointer to a TebVisualization instance
    * @see visualizeTeb
    */
-  void setVisualization(TebVisualizationPtr visualization);
+  void setVisualization(const TebVisualizationPtr & visualization) override;
 
    /**
     * @brief Publish the local plan, pose sequence and additional information via ros topics (e.g. subscribe with rviz).

--- a/teb_local_planner/include/teb_local_planner/optimal_planner.h
+++ b/teb_local_planner/include/teb_local_planner/optimal_planner.h
@@ -330,7 +330,7 @@ public:
    * @param visualization shared pointer to a TebVisualization instance
    * @see visualize
    */
-  void setVisualization(TebVisualizationPtr visualization);
+  void setVisualization(const TebVisualizationPtr & visualization) override;
   
   /**
    * @brief Publish the local plan and pose sequence via ros topics (e.g. subscribe with rviz).

--- a/teb_local_planner/include/teb_local_planner/planner_interface.h
+++ b/teb_local_planner/include/teb_local_planner/planner_interface.h
@@ -59,6 +59,7 @@
 
 // this package
 #include "teb_local_planner/pose_se2.h"
+#include "teb_local_planner/visualization.h"
 
 namespace teb_local_planner
 {
@@ -167,6 +168,8 @@ public:
   virtual void visualize()
   {
   }
+
+  virtual void setVisualization(const TebVisualizationPtr & visualization) = 0;
   
   /**
    * @brief Check whether the planned trajectory is feasible or not.

--- a/teb_local_planner/include/teb_local_planner/visualization.h
+++ b/teb_local_planner/include/teb_local_planner/visualization.h
@@ -81,29 +81,12 @@ class TebOptimalPlanner; //!< Forward Declaration
 class TebVisualization
 {
 public:
-    
-  /**
-   * @brief Default constructor
-   * @remarks do not forget to call initialize()
-   */
-  TebVisualization();
-  
   /**
    * @brief Constructor that initializes the class and registers topics
    * @param nh local rclcpp::Node::SharedPtr
    * @param cfg const reference to the TebConfig class for parameters
    */
-  TebVisualization(nav2_util::LifecycleNode::SharedPtr nh, const TebConfig& cfg);
-  
-  /**
-   * @brief Initializes the class and registers topics.
-   * 
-   * Call this function if only the default constructor has been called before.
-   * @param nh local rclcpp::Node::SharedPtr
-   * @param cfg const reference to the TebConfig class for parameters
-   */
-  void initialize(nav2_util::LifecycleNode::SharedPtr nh, const TebConfig& cfg);
-  
+  TebVisualization(const rclcpp_lifecycle::LifecycleNode::SharedPtr & nh, const TebConfig& cfg);
   
   /** @name Publish to topics */
   //@{
@@ -231,9 +214,10 @@ public:
    */
   void publishFeedbackMessage(const TebOptimalPlanner& teb_planner, const ObstContainer& obstacles);
   
-  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State & state);
-  nav2_util::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state);
-  nav2_util::CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state);
+  nav2_util::CallbackReturn on_configure();
+  nav2_util::CallbackReturn on_activate();
+  nav2_util::CallbackReturn on_deactivate();
+  nav2_util::CallbackReturn on_cleanup();
   
   //@}
 

--- a/teb_local_planner/src/homotopy_class_planner.cpp
+++ b/teb_local_planner/src/homotopy_class_planner.cpp
@@ -80,7 +80,7 @@ void HomotopyClassPlanner::initialize(nav2_util::LifecycleNode::SharedPtr node, 
 }
 
 
-void HomotopyClassPlanner::setVisualization(TebVisualizationPtr visualization)
+void HomotopyClassPlanner::setVisualization(const TebVisualizationPtr& visualization)
 {
   visualization_ = visualization;
 }

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -82,8 +82,7 @@ void TebOptimalPlanner::initialize(nav2_util::LifecycleNode::SharedPtr node, con
   via_points_ = via_points;
   cost_ = HUGE_VAL;
   prefer_rotdir_ = RotType::none;
-  setVisualization(visual);
-  
+
   vel_start_.first = true;
   vel_start_.second.linear.x = 0;
   vel_start_.second.linear.y = 0;
@@ -97,7 +96,7 @@ void TebOptimalPlanner::initialize(nav2_util::LifecycleNode::SharedPtr node, con
 }
 
 
-void TebOptimalPlanner::setVisualization(TebVisualizationPtr visualization)
+void TebOptimalPlanner::setVisualization(const TebVisualizationPtr& visualization)
 {
   visualization_ = visualization;
 }

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -100,9 +100,6 @@ void TebLocalPlannerROS::initialize()
     // reserve some memory for obstacles
     obstacles_.reserve(500);
         
-    // create visualization instance	
-    visualization_ = TebVisualizationPtr(new TebVisualization(nh_, *cfg_.get()));
-        
     // create robot footprint/contour model for optimization
     RobotFootprintModelPtr robot_model = getRobotFootprintFromParamServer();
     
@@ -214,6 +211,9 @@ void TebLocalPlannerROS::configure(
   name_ = name;
 
   initialize();
+  visualization_ = std::make_shared<TebVisualization>(nh_, *cfg_);
+  visualization_->on_configure();
+  planner_->setVisualization(visualization_);
   
   return;
 }
@@ -1203,19 +1203,17 @@ RobotFootprintModelPtr TebLocalPlannerROS::getRobotFootprintFromParamServer()
 }
 
 void TebLocalPlannerROS::activate() {
-  rclcpp_lifecycle::State state;
-  visualization_->on_activate(state);
+  visualization_->on_activate();
 
   return;
 }
 void TebLocalPlannerROS::deactivate() {
-  rclcpp_lifecycle::State state;
-  visualization_->on_deactivate(state);
+  visualization_->on_deactivate();
 
   return;
 }
 void TebLocalPlannerROS::cleanup() {
-  visualization_.reset();
+  visualization_->on_cleanup();
   costmap_converter_->stopWorker();
   
   return;


### PR DESCRIPTION
Starting things in the current order caused a race condition when using newer ros2 versions. This fixes https://github.com/rst-tu-dortmund/teb_local_planner/issues/196. There might be a cleaner way to fix this, but this works and should at least get the idea across. Unfortunately I can only invest limited amounts of time at the moment. 