### PR TITLE
Fix compilation error for Foxy

### DIFF
--- a/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
+++ b/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
@@ -138,7 +138,7 @@ public:
 
   bool isGoalReached(
     const geometry_msgs::msg::PoseStamped & pose,
-    const geometry_msgs::msg::Twist & velocity) override;
+    const geometry_msgs::msg::Twist & velocity);
 
   /**
     * @brief  Check if the goal pose has been achieved


### PR DESCRIPTION
Hi,

Some warning in Eloquent are errors in Foxy, due to the compiler version. This fixes the error.

Best