### PR TITLE
Fixed fatal error: mbf_costmap_core/costmap_controller.h: No such fil…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ catkin_package(
 	nav_msgs
 	pluginlib
 	roscpp
+  mbf_costmap_core
 	std_msgs
         tf2
         tf2_ros


### PR DESCRIPTION
`fatal error: mbf_costmap_core/costmap_controller.h: No such file or directory
 #include <mbf_costmap_core/costmap_controller.h>
`

I cloned the mbf_costmap_core package with git. Then I couldn't find costmap_controller.h. So I added the include directory. Then I solved!