### PR TITLE
increase allowed weight_kinematics_forward_drive

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -261,12 +261,12 @@ grp_optimization.add("weight_kinematics_nh", double_t, 0,
 	1000 , 0, 10000) 
 
 grp_optimization.add("weight_kinematics_forward_drive", double_t, 0, 
-	"Optimization weight for forcing the robot to choose only forward directions (positive transl. velocities, only diffdrive robot)", 
-	1, 0, 1000) 
+  "Optimization weight for forcing the robot to choose only forward directions (positive transl. velocities, only diffdrive robot)",
+  1, 0, 10000)
 	
 grp_optimization.add("weight_kinematics_turning_radius", double_t, 0, 
   "Optimization weight for enforcing a minimum turning radius (carlike robots)", 
-  1, 0, 1000) 
+  1, 0, 1000)
 
 grp_optimization.add("weight_optimaltime", double_t, 0, 
         "Optimization weight for contracting the trajectory w.r.t. transition time",


### PR DESCRIPTION
In order to enforce forward movement only, weight_kinematics_forward_drive needs to be set higher, this PR allows it to be set to 10000.
Solves https://github.com/rst-tu-dortmund/teb_local_planner/issues/85 for my configuration