### PR TITLE
Improve the performance of computing sin and cos functions

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -390,4 +390,16 @@ grp_recovery.add("oscillation_recovery",   bool_t,   0,
   "Try to detect and resolve oscillations between multiple solutions in the same equivalence class (robot frequently switches between left/right/forward/backwards).",
   True) 
   
+
+# Performance
+grp_performance = gen.add_group("Performance", type="tab")
+
+grp_performance.add(
+	"use_sin_cos_approximation",
+	bool_t,
+	0,
+	"Use sin and cos approximations to improve performance. The maximum absolute error for these approximations is 1e-3.",
+	False
+)
+
 exit(gen.generate("teb_local_planner", "teb_local_planner", "TebLocalPlannerReconfigure"))

--- a/include/teb_local_planner/misc.h
+++ b/include/teb_local_planner/misc.h
@@ -147,6 +147,107 @@ inline const T& get_const_reference(const T* ptr) {return *ptr;}
 template<typename T>
 inline const T& get_const_reference(const T& val, typename boost::disable_if<boost::is_pointer<T> >::type* dummy = 0) {return val;}
 
+template <typename T>
+inline void sincos_approx(T angle, T &sin, T &cos)
+{
+  // Least squares for sin(x) = a0 + a1 * x + a2 * x^2 in [0, pi/4]
+  const static T a0 = -0.00377382f;
+  const static T a1 = 1.0583384f;
+  const static T a2 =  -0.18924264f;
+  // Least squares for cos(x) = b0 + b1 * x + b2 * x^2 in [0, pi/4]
+  const static T b0 = 1.00132026f;
+  const static T b1 = -0.01798667f;
+  const static T b2 = -0.45687215f;
+  // Find the quadrant
+  bool quad_3_or_4 = false;
+  if (angle < 0)
+    angle = angle + 2 * static_cast<T>(M_PI);
+  if (angle > static_cast<T>(M_PI))
+  {
+    angle = angle - static_cast<T>(M_PI);
+    quad_3_or_4 = true;
+  }
+  if (angle > 3 * static_cast<T>(M_PI_4))
+  {
+    angle = static_cast<T>(M_PI) - angle;
+    T angle2 = angle * angle;
+    sin =   a0 + a1 * angle + a2 * angle2;
+    cos = -(b0 + b1 * angle + b2 * angle2);
+  }
+  else if (angle > static_cast<T>(M_PI_2))
+  {
+    angle = angle - static_cast<T>(M_PI_2);
+    T angle2 = angle * angle;
+    cos = -(a0 + a1 * angle + a2 * angle2);
+    sin =   b0 + b1 * angle + b2 * angle2;
+  }
+  else if (angle > static_cast<T>(M_PI_4))
+  {
+    angle = static_cast<T>(M_PI_2) - angle;
+    T angle2 = angle * angle;
+    cos = a0 + a1 * angle + a2 * angle2;
+    sin = b0 + b1 * angle + b2 * angle2;
+  }
+  else
+  {
+    T angle2 = angle * angle;
+    sin = a0 + a1 * angle + a2 * angle2;
+    cos = b0 + b1 * angle + b2 * angle2;
+  }
+  if (quad_3_or_4)
+  {
+    sin = -sin;
+    cos = -cos;
+  }
+};
+
+template <typename T>
+inline void sin_approx(T angle, T &sin)
+{
+  // Least squares for sin(x) = a0 + a1 * x + a2 * x^2 in [0, pi/4]
+  const static T a0 = -0.00377382f;
+  const static T a1 = 1.0583384f;
+  const static T a2 =  -0.18924264f;
+  // Least squares for cos(x) = b0 + b1 * x + b2 * x^2 in [0, pi/4]
+  const static T b0 = 1.00132026f;
+  const static T b1 = -0.01798667f;
+  const static T b2 = -0.45687215f;
+  // Find the quadrant
+  bool quad_3_or_4 = false;
+  if (angle < 0)
+    angle = angle + 2 * static_cast<T>(M_PI);
+  if (angle > static_cast<T>(M_PI))
+  {
+    angle = angle - static_cast<T>(M_PI);
+    quad_3_or_4 = true;
+  }
+  if (angle > 3 * static_cast<T>(M_PI_4))
+  {
+    angle = static_cast<T>(M_PI) - angle;
+    T angle2 = angle * angle;
+    sin =   a0 + a1 * angle + a2 * angle2;
+  }
+  else if (angle > static_cast<T>(M_PI_2))
+  {
+    angle = angle - static_cast<T>(M_PI_2);
+    T angle2 = angle * angle;
+    sin =   b0 + b1 * angle + b2 * angle2;
+  }
+  else if (angle > static_cast<T>(M_PI_4))
+  {
+    angle = static_cast<T>(M_PI_2) - angle;
+    T angle2 = angle * angle;
+    sin = b0 + b1 * angle + b2 * angle2;
+  }
+  else
+  {
+    T angle2 = angle * angle;
+    sin = a0 + a1 * angle + a2 * angle2;
+  }
+  if (quad_3_or_4)
+    sin = -sin;
+};
+
 } // namespace teb_local_planner
 
 #endif /* MISC_H */

--- a/include/teb_local_planner/misc.h
+++ b/include/teb_local_planner/misc.h
@@ -147,106 +147,34 @@ inline const T& get_const_reference(const T* ptr) {return *ptr;}
 template<typename T>
 inline const T& get_const_reference(const T& val, typename boost::disable_if<boost::is_pointer<T> >::type* dummy = 0) {return val;}
 
-template <typename T>
-inline void sincos_approx(T angle, T &sin, T &cos)
+inline float sin_fast(float angle)
 {
-  // Least squares for sin(x) = a0 + a1 * x + a2 * x^2 in [0, pi/4]
-  const static T a0 = -0.00377382f;
-  const static T a1 = 1.0583384f;
-  const static T a2 =  -0.18924264f;
-  // Least squares for cos(x) = b0 + b1 * x + b2 * x^2 in [0, pi/4]
-  const static T b0 = 1.00132026f;
-  const static T b1 = -0.01798667f;
-  const static T b2 = -0.45687215f;
-  // Find the quadrant
-  bool quad_3_or_4 = false;
-  if (angle < 0)
-    angle = angle + 2 * static_cast<T>(M_PI);
-  if (angle > static_cast<T>(M_PI))
-  {
-    angle = angle - static_cast<T>(M_PI);
-    quad_3_or_4 = true;
-  }
-  if (angle > 3 * static_cast<T>(M_PI_4))
-  {
-    angle = static_cast<T>(M_PI) - angle;
-    T angle2 = angle * angle;
-    sin =   a0 + a1 * angle + a2 * angle2;
-    cos = -(b0 + b1 * angle + b2 * angle2);
-  }
-  else if (angle > static_cast<T>(M_PI_2))
-  {
-    angle = angle - static_cast<T>(M_PI_2);
-    T angle2 = angle * angle;
-    cos = -(a0 + a1 * angle + a2 * angle2);
-    sin =   b0 + b1 * angle + b2 * angle2;
-  }
-  else if (angle > static_cast<T>(M_PI_4))
-  {
-    angle = static_cast<T>(M_PI_2) - angle;
-    T angle2 = angle * angle;
-    cos = a0 + a1 * angle + a2 * angle2;
-    sin = b0 + b1 * angle + b2 * angle2;
-  }
-  else
-  {
-    T angle2 = angle * angle;
-    sin = a0 + a1 * angle + a2 * angle2;
-    cos = b0 + b1 * angle + b2 * angle2;
-  }
-  if (quad_3_or_4)
-  {
-    sin = -sin;
-    cos = -cos;
-  }
-};
+  // Code borrowed from https://github.com/kennyalive/fast-sine-cosine
+  constexpr float PI = 3.14159265358f;
+  constexpr float PI2 = 2 * PI;
+  constexpr float B = 4.0f / PI;
+  constexpr float C = -4.0f / (PI * PI);
+  constexpr float P = 0.225f;
 
-template <typename T>
-inline void sin_approx(T angle, T &sin)
+  angle = std::fmod(angle, PI2);
+  if (angle > PI)
+    angle -= PI2;
+
+  angle = B * angle + C * angle * (angle < 0 ? -angle : angle);
+  return P * (angle * (angle < 0 ? -angle : angle) - angle) + angle;
+}
+
+inline float cos_fast(float angle)
 {
-  // Least squares for sin(x) = a0 + a1 * x + a2 * x^2 in [0, pi/4]
-  const static T a0 = -0.00377382f;
-  const static T a1 = 1.0583384f;
-  const static T a2 =  -0.18924264f;
-  // Least squares for cos(x) = b0 + b1 * x + b2 * x^2 in [0, pi/4]
-  const static T b0 = 1.00132026f;
-  const static T b1 = -0.01798667f;
-  const static T b2 = -0.45687215f;
-  // Find the quadrant
-  bool quad_3_or_4 = false;
-  if (angle < 0)
-    angle = angle + 2 * static_cast<T>(M_PI);
-  if (angle > static_cast<T>(M_PI))
-  {
-    angle = angle - static_cast<T>(M_PI);
-    quad_3_or_4 = true;
-  }
-  if (angle > 3 * static_cast<T>(M_PI_4))
-  {
-    angle = static_cast<T>(M_PI) - angle;
-    T angle2 = angle * angle;
-    sin =   a0 + a1 * angle + a2 * angle2;
-  }
-  else if (angle > static_cast<T>(M_PI_2))
-  {
-    angle = angle - static_cast<T>(M_PI_2);
-    T angle2 = angle * angle;
-    sin =   b0 + b1 * angle + b2 * angle2;
-  }
-  else if (angle > static_cast<T>(M_PI_4))
-  {
-    angle = static_cast<T>(M_PI_2) - angle;
-    T angle2 = angle * angle;
-    sin = b0 + b1 * angle + b2 * angle2;
-  }
-  else
-  {
-    T angle2 = angle * angle;
-    sin = a0 + a1 * angle + a2 * angle2;
-  }
-  if (quad_3_or_4)
-    sin = -sin;
-};
+  // Code borrowed from https://github.com/kennyalive/fast-sine-cosine
+  constexpr float PI = 3.14159265358f;
+  constexpr float PI2 = 2 * PI;
+
+  angle = (angle > 0) ? -angle : angle;
+  angle += PI/2;
+
+  return sin_fast(angle);
+}
 
 } // namespace teb_local_planner
 

--- a/include/teb_local_planner/robot_footprint_model.h
+++ b/include/teb_local_planner/robot_footprint_model.h
@@ -42,6 +42,7 @@
 
 #include <teb_local_planner/pose_se2.h>
 #include <teb_local_planner/obstacles.h>
+#include <teb_local_planner/misc.h>
 #include <visualization_msgs/Marker.h>
 
 namespace teb_local_planner
@@ -516,8 +517,8 @@ private:
     */
   void transformToWorld(const PoseSE2& current_pose, Eigen::Vector2d& line_start_world, Eigen::Vector2d& line_end_world) const
   {
-    double cos_th = std::cos(current_pose.theta());
-    double sin_th = std::sin(current_pose.theta());
+    double sin_th, cos_th;
+    teb_local_planner::sincos_approx(current_pose.theta(), sin_th, cos_th);
     line_start_world.x() = current_pose.x() + cos_th * line_start_.x() - sin_th * line_start_.y();
     line_start_world.y() = current_pose.y() + sin_th * line_start_.x() + cos_th * line_start_.y();
     line_end_world.x() = current_pose.x() + cos_th * line_end_.x() - sin_th * line_end_.y();

--- a/include/teb_local_planner/robot_footprint_model.h
+++ b/include/teb_local_planner/robot_footprint_model.h
@@ -320,8 +320,9 @@ public:
     */
   virtual double calculateDistance(const PoseSE2& current_pose, const Obstacle* obstacle) const
   {
-    double sin_th, cos_th;
-    cfg_->sincos(current_pose.theta(), sin_th, cos_th);
+    double sin_th = cfg_->sin(current_pose.theta());
+    double cos_th = cfg_->cos(current_pose.theta());
+
     Eigen::Vector2d dir(cos_th, sin_th);
     double dist_front = obstacle->getMinimumDistance(current_pose.position() + front_offset_*dir) - front_radius_;
     double dist_rear = obstacle->getMinimumDistance(current_pose.position() - rear_offset_*dir) - rear_radius_;
@@ -337,8 +338,9 @@ public:
     */
   virtual double estimateSpatioTemporalDistance(const PoseSE2& current_pose, const Obstacle* obstacle, double t) const
   {
-    double sin_th, cos_th;
-    cfg_->sincos(current_pose.theta(), sin_th, cos_th);
+    double sin_th = cfg_->sin(current_pose.theta());
+    double cos_th = cfg_->cos(current_pose.theta());
+
     Eigen::Vector2d dir(cos_th, sin_th);
     double dist_front = obstacle->getMinimumSpatioTemporalDistance(current_pose.position() + front_offset_*dir, t) - front_radius_;
     double dist_rear = obstacle->getMinimumSpatioTemporalDistance(current_pose.position() - rear_offset_*dir, t) - rear_radius_;
@@ -356,8 +358,9 @@ public:
     */
   virtual void visualizeRobot(const PoseSE2& current_pose, std::vector<visualization_msgs::Marker>& markers, const std_msgs::ColorRGBA& color) const
   {
-    double sin_th, cos_th;
-    cfg_->sincos(current_pose.theta(), sin_th, cos_th);
+    double sin_th = cfg_->sin(current_pose.theta());
+    double cos_th = cfg_->cos(current_pose.theta());
+
     Eigen::Vector2d dir(cos_th, sin_th);
     if (front_radius_>0)
     {
@@ -544,8 +547,9 @@ private:
     */
   void transformToWorld(const PoseSE2& current_pose, Eigen::Vector2d& line_start_world, Eigen::Vector2d& line_end_world) const
   {
-    double sin_th, cos_th;
-    cfg_->sincos(current_pose.theta(), sin_th, cos_th);
+    double sin_th = cfg_->sin(current_pose.theta());
+    double cos_th = cfg_->cos(current_pose.theta());
+
     line_start_world.x() = current_pose.x() + cos_th * line_start_.x() - sin_th * line_start_.y();
     line_start_world.y() = current_pose.y() + sin_th * line_start_.x() + cos_th * line_start_.y();
     line_end_world.x() = current_pose.x() + cos_th * line_end_.x() - sin_th * line_end_.y();
@@ -690,10 +694,8 @@ private:
     */
   void transformToWorld(const PoseSE2& current_pose, Point2dContainer& polygon_world) const
   {
-    double cos_th;
-    double sin_th;
-
-    cfg_->sincos(current_pose.theta(), sin_th, cos_th);
+    double sin_th = cfg_->sin(current_pose.theta());
+    double cos_th = cfg_->cos(current_pose.theta());
 
     for (std::size_t i=0; i<vertices_.size(); ++i)
     {

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -45,6 +45,7 @@
 #include <Eigen/StdVector>
 
 #include <teb_local_planner/TebLocalPlannerReconfigureConfig.h>
+#include <teb_local_planner/misc.h>
 
 
 // Definitions
@@ -215,6 +216,12 @@ public:
     double oscillation_filter_duration; //!< Filter length/duration [sec] for the detection of oscillations
   } recovery; //!< Parameters related to recovery and backup strategies
 
+  //! Performance enhancement related parameters
+  struct Performance
+  {
+    bool use_sin_cos_approximation; //!< Use sin and cos approximations to improve performance. The maximum absolute error for these approximations is 1e-3.
+  } performance;
+
 
   /**
   * @brief Construct the TebConfig using default values.
@@ -366,6 +373,9 @@ public:
     recovery.oscillation_recovery_min_duration = 10;
     recovery.oscillation_filter_duration = 10;
 
+    // Recovery
+
+    performance.use_sin_cos_approximation = false;
 
   }
 
@@ -398,6 +408,27 @@ public:
    * @param nh const reference to the local ros::NodeHandle
    */
   void checkDeprecated(const ros::NodeHandle& nh) const;
+
+  template <typename T>
+  inline void sincos(T angle, T& sin, T& cos) const
+  {
+    if (performance.use_sin_cos_approximation)
+      teb_local_planner::sincos_approx(angle, sin, cos);
+    else
+    {
+      sin = std::sin(angle);
+      cos = std::cos(angle);
+    }
+  }
+
+  template <typename T>
+  inline void sin(T angle, T& sin) const
+  {
+    if (performance.use_sin_cos_approximation)
+      teb_local_planner::sin_approx(angle, sin);
+    else
+      sin = std::sin(angle);
+  }
 
   /**
    * @brief Return the internal config mutex

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -410,24 +410,15 @@ public:
   void checkDeprecated(const ros::NodeHandle& nh) const;
 
   template <typename T>
-  inline void sincos(T angle, T& sin, T& cos) const
+  T cos(T angle) const
   {
-    if (performance.use_sin_cos_approximation)
-      teb_local_planner::sincos_approx(angle, sin, cos);
-    else
-    {
-      sin = std::sin(angle);
-      cos = std::cos(angle);
-    }
+    return performance.use_sin_cos_approximation ? teb_local_planner::cos_fast(angle) : std::cos(angle);
   }
 
   template <typename T>
-  inline void sin(T angle, T& sin) const
+  T sin(T angle) const
   {
-    if (performance.use_sin_cos_approximation)
-      teb_local_planner::sin_approx(angle, sin);
-    else
-      sin = std::sin(angle);
+    return performance.use_sin_cos_approximation ? teb_local_planner::sin_fast(angle) : std::sin(angle);
   }
 
   /**

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -64,6 +64,7 @@ void HomotopyClassPlanner::initialize(const TebConfig& cfg, ObstContainer* obsta
   obstacles_ = obstacles;
   via_points_ = via_points;
   robot_model_ = robot_model;
+  robot_model_->setTEBConfiguration(cfg_);
 
   if (cfg_->hcp.simple_exploration)
     graph_search_ = boost::shared_ptr<GraphSearchInterface>(new lrKeyPointGraph(*cfg_, this));

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -87,6 +87,7 @@ void TebOptimalPlanner::initialize(const TebConfig& cfg, ObstContainer* obstacle
   cfg_ = &cfg;
   obstacles_ = obstacles;
   robot_model_ = robot_model;
+  robot_model_->setTEBConfiguration(cfg_);
   via_points_ = via_points;
   cost_ = HUGE_VAL;
   prefer_rotdir_ = RotType::none;

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -168,6 +168,9 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("oscillation_recovery_min_duration", recovery.oscillation_recovery_min_duration, recovery.oscillation_recovery_min_duration);
   nh.param("oscillation_filter_duration", recovery.oscillation_filter_duration, recovery.oscillation_filter_duration);
 
+  // Performance
+  nh.param("use_sin_cos_approximation", performance.use_sin_cos_approximation, performance.use_sin_cos_approximation);
+
   checkParameters();
   checkDeprecated(nh);
 }
@@ -274,6 +277,10 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   
   recovery.shrink_horizon_backup = cfg.shrink_horizon_backup;
   recovery.oscillation_recovery = cfg.oscillation_recovery;
+
+  // Performance
+
+  performance.use_sin_cos_approximation = cfg.use_sin_cos_approximation;
   
   checkParameters();
 }

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -102,6 +102,7 @@ void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costm
         
     // create robot footprint/contour model for optimization
     RobotFootprintModelPtr robot_model = getRobotFootprintFromParamServer(nh);
+    robot_model->setTEBConfiguration(cfg_);
     
     // create the planner instance
     if (cfg_.hcp.enable_homotopy_class_planning)

--- a/src/test_optim_node.cpp
+++ b/src/test_optim_node.cpp
@@ -148,6 +148,7 @@ int main( int argc, char** argv )
   
   // Setup robot shape model
   RobotFootprintModelPtr robot_model = TebLocalPlannerROS::getRobotFootprintFromParamServer(n);
+  robot_model->setTEBConfiguration(config);
   
   // Setup planner (homotopy class planning or just the local teb planner)
   if (config.hcp.enable_homotopy_class_planning)


### PR DESCRIPTION
Once again, this PR affects quite a lot of files, but the change is actually not that big; besides, it is optional. :nerd_face:

### TL;DR
For me, this PR saves 40% CPU without any noticeable impact on convergence. The maximum absolute error between the analytic `sin` and `cos` functions and the approximations is 0.003.

### Why
In the application I work on, the major performance bottleneck we faced when using TEB was computing three simple functions: `sin`, `cos`, and `pow`. Initially, that came as a surprise for me, but it does make sense since these functions must be used all over to compute the graph edges.

### Summary
There are basically two ways of speeding up the computation of trigonometric functions: look-up tables and mathematical approximations. I did not benchmark any of the other ways, but I am confident the approximation I used is more than enough to disappear with the performance bottleneck due to the trigonometric functions.

### Comparison
As an example, this is the typical flame graph I get without the trigonometric approximations (sorry, but I had to blur the image where proprietary code is called).
![teb_before](https://user-images.githubusercontent.com/5129986/95656481-f737a980-0b0e-11eb-8dc0-6d689ccea3fb.png)

And this one is with approximations for `sin` and `cos`.
![teb_sincos](https://user-images.githubusercontent.com/5129986/95656487-0ae31000-0b0f-11eb-910d-9ff806ce0e4e.png)

So, for me, the improvement was roughly 40% less CPU usage.

### Parameters
`use_sin_cos_approximation` under a new tab called "Performance". This toggles the approximations and defaults to `false`.

### Formula
It is a pretty simple approximation, I take a second-order approximation in the 0 to 45 degrees interval, and then use trigonometric identities to replicate the result to the other quadrants. For comparison, these are the analytic functions and their approximations.
![image](https://user-images.githubusercontent.com/5129986/95656595-bee49b00-0b0f-11eb-97e0-7751675d2439.png)

And these are the absolute errors.
![image](https://user-images.githubusercontent.com/5129986/95656621-e2a7e100-0b0f-11eb-85d1-9dad7e1b2c16.png)


