### PR TITLE
Updateable robot model

### DIFF
--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -143,6 +143,7 @@ public:
                   TebVisualizationPtr visualization = TebVisualizationPtr(), const ViaPointContainer* via_points = NULL);
 
 
+  void updateRobotModel(RobotFootprintModelPtr robot_model );
 
   /** @name Plan a trajectory */
   //@{

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -144,8 +144,11 @@ public:
   void initialize(const TebConfig& cfg, ObstContainer* obstacles = NULL, RobotFootprintModelPtr robot_model = boost::make_shared<PointRobotFootprint>(),
                   TebVisualizationPtr visual = TebVisualizationPtr(), const ViaPointContainer* via_points = NULL);
   
+  /**
+    * @param robot_model Shared pointer to the robot shape model used for optimization (optional)
+    */
+  void updateRobotModel(RobotFootprintModelPtr robot_model );
   
-
   /** @name Plan a trajectory  */
   //@{
   

--- a/include/teb_local_planner/planner_interface.h
+++ b/include/teb_local_planner/planner_interface.h
@@ -48,6 +48,7 @@
 
 // this package
 #include <teb_local_planner/pose_se2.h>
+#include <teb_local_planner/robot_footprint_model.h>
 
 // messages
 #include <geometry_msgs/PoseArray.h>
@@ -160,6 +161,10 @@ public:
   {
   }
   
+  virtual void updateRobotModel(RobotFootprintModelPtr robot_model)
+  {
+  }
+
   /**
    * @brief Check whether the planned trajectory is feasible or not.
    * 

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -439,6 +439,7 @@ private:
   
   std::string global_frame_; //!< The frame in which the controller will run
   std::string robot_base_frame_; //!< Used as the base frame id of the robot
+  std::string name_; //!< For use with the ros nodehandle
     
   // flags
   bool initialized_; //!< Keeps track about the correct initialization of this class

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -75,6 +75,10 @@ void HomotopyClassPlanner::initialize(const TebConfig& cfg, ObstContainer* obsta
   setVisualization(visual);
 }
 
+void HomotopyClassPlanner::updateRobotModel(RobotFootprintModelPtr robot_model )
+{
+  robot_model_ = robot_model;
+}
 
 void HomotopyClassPlanner::setVisualization(TebVisualizationPtr visualization)
 {

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -67,6 +67,11 @@ TebOptimalPlanner::~TebOptimalPlanner()
   //g2o::HyperGraphActionLibrary::destroy();
 }
 
+void TebOptimalPlanner::updateRobotModel(RobotFootprintModelPtr robot_model)
+{
+  robot_model_ = robot_model;
+}
+
 void TebOptimalPlanner::initialize(const TebConfig& cfg, ObstContainer* obstacles, RobotFootprintModelPtr robot_model, TebVisualizationPtr visual, const ViaPointContainer* via_points)
 {    
   // init optimizer (set solver and block ordering settings)

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -81,6 +81,10 @@ TebLocalPlannerROS::~TebLocalPlannerROS()
 void TebLocalPlannerROS::reconfigureCB(TebLocalPlannerReconfigureConfig& config, uint32_t level)
 {
   cfg_.reconfigure(config);
+  ros::NodeHandle nh("~/" + name_);
+  // create robot footprint/contour model for optimization
+  RobotFootprintModelPtr robot_model = getRobotFootprintFromParamServer(nh);
+  planner_->updateRobotModel(robot_model);
 }
 
 void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costmap_2d::Costmap2DROS* costmap_ros)
@@ -88,6 +92,7 @@ void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costm
   // check if the plugin is already initialized
   if(!initialized_)
   {	
+    name_ = name;
     // create Node Handle with name of plugin (as used in move_base for loading)
     ros::NodeHandle nh("~/" + name);
 	        


### PR DESCRIPTION
This allows the robot footprint model to be updated. The current "Is_footprint_dynamic" dynamically reconfigurable parameter only updates the global planner footprint to check feasibility. This change allows updating the actual model, even changing the model type.  To use, first update the values on the parameter server, then call the dynamic reconfigure service. No need to reconfigure anything though, it's the call that triggers the update. So if the footprint_dynamic is set to true, calling the service to set it to true again will update the model  (unless someone wants to implement a separate service call...).

Tested on melodic.