### PR TITLE
bulk-delete the edges registered at the vertices

### DIFF
--- a/include/teb_local_planner/g2o_types/base_teb_edges.h
+++ b/include/teb_local_planner/g2o_types/base_teb_edges.h
@@ -75,26 +75,6 @@ public:
   using g2o::BaseUnaryEdge<D, E, VertexXi>::computeError;
     
   /**
-   * @brief Construct edge.
-   */  
-  BaseTebUnaryEdge()
-  {
-      _vertices[0] = NULL;
-  }
-  
-  /**
-   * @brief Destruct edge.
-   * 
-   * We need to erase vertices manually, since we want to keep them even if TebOptimalPlanner::clearGraph() is called.
-   * This is necessary since the vertices are managed by the Timed_Elastic_Band class.
-   */   
-  virtual ~BaseTebUnaryEdge()
-  {
-      if(_vertices[0])
-        _vertices[0]->edges().erase(this);
-  }
-
-  /**
   * @brief Compute and return error / cost value.
   * 
   * This method is called by TebOptimalPlanner::computeCurrentCost to obtain the current cost.
@@ -161,28 +141,6 @@ public:
     
   using typename g2o::BaseBinaryEdge<D, E, VertexXi, VertexXj>::ErrorVector;
   using g2o::BaseBinaryEdge<D, E, VertexXi, VertexXj>::computeError;
-  
-  /**
-   * @brief Construct edge.
-   */  
-  BaseTebBinaryEdge()
-  {
-      _vertices[0] = _vertices[1] = NULL;
-  }
-  
-  /**
-   * @brief Destruct edge.
-   * 
-   * We need to erase vertices manually, since we want to keep them even if TebOptimalPlanner::clearGraph() is called.
-   * This is necessary since the vertices are managed by the Timed_Elastic_Band class.
-   */   
-  virtual ~BaseTebBinaryEdge()
-  {
-    if(_vertices[0])
-        _vertices[0]->edges().erase(this);
-    if(_vertices[1])
-        _vertices[1]->edges().erase(this);
-  }
 
   /**
   * @brief Compute and return error / cost value.
@@ -253,30 +211,6 @@ public:
   using typename g2o::BaseMultiEdge<D, E>::ErrorVector;
   using g2o::BaseMultiEdge<D, E>::computeError;
     
-  /**
-   * @brief Construct edge.
-   */  
-  BaseTebMultiEdge()
-  {
-//     for(std::size_t i=0; i<_vertices.size(); ++i)
-//         _vertices[i] = NULL;
-  }
-  
-  /**
-   * @brief Destruct edge.
-   * 
-   * We need to erase vertices manually, since we want to keep them even if TebOptimalPlanner::clearGraph() is called.
-   * This is necessary since the vertices are managed by the Timed_Elastic_Band class.
-   */   
-  virtual ~BaseTebMultiEdge()
-  {
-    for(std::size_t i=0; i<_vertices.size(); ++i)
-    {
-        if(_vertices[i])
-            _vertices[i]->edges().erase(this);
-    }
-  }
-  
   // Overwrites resize() from the parent class
   virtual void resize(size_t size)
   {

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -410,8 +410,13 @@ void TebOptimalPlanner::clearGraph()
   // clear optimizer states
   if (optimizer_)
   {
-    //optimizer.edges().clear(); // optimizer.clear deletes edges!!! Therefore do not run optimizer.edges().clear()
-    optimizer_->vertices().clear();  // neccessary, because optimizer->clear deletes pointer-targets (therefore it deletes TEB states!)
+    // we will delete all edges but keep the vertices.
+    // before doing so, we will delete the link from the vertices to the edges.
+    auto& vertices = optimizer_->vertices();
+    for(auto& v : vertices)
+      v.second->edges().clear();
+
+    optimizer_->vertices().clear();  // necessary, because optimizer->clear deletes pointer-targets (therefore it deletes TEB states!)
     optimizer_->clear();
   }
 }


### PR DESCRIPTION
PR simplifies the formulation of the base-edges and offers a small speed-up of the clearGraph function.

1. The constructors can be removed, since g2o already initializes the vertices members to nullptr
- https://github.com/RainerKuemmerle/g2o/blob/832b96340c626ed75b767ec4867b95ce7abf8093/g2o/core/base_unary_edge.h#L55
- https://github.com/RainerKuemmerle/g2o/blob/832b96340c626ed75b767ec4867b95ce7abf8093/g2o/core/base_binary_edge.h#L69

2. The deletion of the non-owning _vertices.edges-member can be done at once for all edges inside the clearGraph function.
In this way don't have to pay the price for the lookup inside std::set<Edge>::erase

