### PR TITLE
Dima/cleanup

### DIFF
--- a/include/teb_local_planner/g2o_types/base_teb_edges.h
+++ b/include/teb_local_planner/g2o_types/base_teb_edges.h
@@ -54,8 +54,28 @@
 
 namespace teb_local_planner
 {
-    
-    
+
+/**
+ * @brief Common interface for setting/getting the TebConfig.
+ *
+ * Class offers a setter/getter interface used by the edges of this library.
+ */
+struct ConfigInterface{
+
+  inline const TebConfig* getTebConfig() const noexcept
+  {
+    return cfg_;
+  }
+
+  inline void setTebConfig(const TebConfig& _cfg) noexcept
+  {
+    cfg_ = &_cfg;
+  }
+
+protected:
+  const TebConfig* cfg_;
+};
+
 /**
  * @class BaseTebUnaryEdge
  * @brief Base edge connecting a single vertex in the TEB optimization problem
@@ -67,7 +87,8 @@ namespace teb_local_planner
  * @see BaseTebMultiEdge, BaseTebBinaryEdge, g2o::BaseBinaryEdge, g2o::BaseUnaryEdge, g2o::BaseMultiEdge
  */   
 template <int D, typename E, typename VertexXi>
-class BaseTebUnaryEdge : public g2o::BaseUnaryEdge<D, E, VertexXi>
+class BaseTebUnaryEdge : public g2o::BaseUnaryEdge<D, E, VertexXi>,
+                         public ConfigInterface
 {
 public:
 
@@ -89,23 +110,6 @@ public:
     return os.good();
   }
 
-  /**
-   * @brief Assign the TebConfig class for parameters.
-   * @param cfg TebConfig class
-   */ 
-  void setTebConfig(const TebConfig& cfg)
-  {
-    cfg_ = &cfg;
-  }
-    
-protected:
-    
-  using g2o::BaseUnaryEdge<D, E, VertexXi>::_error;
-  using g2o::BaseUnaryEdge<D, E, VertexXi>::_vertices;
-  
-  const TebConfig* cfg_; //!< Store TebConfig class for parameters
-  
-public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW   
 };
 
@@ -120,7 +124,8 @@ public:
  * @see BaseTebMultiEdge, BaseTebUnaryEdge, g2o::BaseBinaryEdge, g2o::BaseUnaryEdge, g2o::BaseMultiEdge
  */    
 template <int D, typename E, typename VertexXi, typename VertexXj>
-class BaseTebBinaryEdge : public g2o::BaseBinaryEdge<D, E, VertexXi, VertexXj>
+class BaseTebBinaryEdge : public g2o::BaseBinaryEdge<D, E, VertexXi, VertexXj>,
+                          public ConfigInterface
 {
 public:
   
@@ -142,23 +147,6 @@ public:
     return os.good();
   }
 
-  /**
-   * @brief Assign the TebConfig class for parameters.
-   * @param cfg TebConfig class
-   */ 
-  void setTebConfig(const TebConfig& cfg)
-  {
-    cfg_ = &cfg;
-  }
-  
-protected:
-  
-  using g2o::BaseBinaryEdge<D, E, VertexXi, VertexXj>::_error;
-  using g2o::BaseBinaryEdge<D, E, VertexXi, VertexXj>::_vertices;
-    
-  const TebConfig* cfg_; //!< Store TebConfig class for parameters
-  
-public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW   
 };
 
@@ -174,7 +162,8 @@ public:
  * @see BaseTebBinaryEdge, BaseTebUnaryEdge, g2o::BaseBinaryEdge, g2o::BaseUnaryEdge, g2o::BaseMultiEdge
  */    
 template <int D, typename E>
-class BaseTebMultiEdge : public g2o::BaseMultiEdge<D, E>
+class BaseTebMultiEdge : public g2o::BaseMultiEdge<D, E>,
+                         public ConfigInterface
 {
 public:
 
@@ -196,23 +185,6 @@ public:
     return os.good();
   }
 
-  /**
-   * @brief Assign the TebConfig class for parameters.
-   * @param cfg TebConfig class
-   */ 
-  void setTebConfig(const TebConfig& cfg)
-  {
-    cfg_ = &cfg;
-  }
-  
-protected:
-    
-  using g2o::BaseMultiEdge<D, E>::_error;
-  using g2o::BaseMultiEdge<D, E>::_vertices;
-  
-  const TebConfig* cfg_; //!< Store TebConfig class for parameters
-  
-public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW   
 };
 

--- a/include/teb_local_planner/g2o_types/base_teb_edges.h
+++ b/include/teb_local_planner/g2o_types/base_teb_edges.h
@@ -70,22 +70,7 @@ template <int D, typename E, typename VertexXi>
 class BaseTebUnaryEdge : public g2o::BaseUnaryEdge<D, E, VertexXi>
 {
 public:
-            
-  using typename g2o::BaseUnaryEdge<D, E, VertexXi>::ErrorVector;
-  using g2o::BaseUnaryEdge<D, E, VertexXi>::computeError;
-    
-  /**
-  * @brief Compute and return error / cost value.
-  * 
-  * This method is called by TebOptimalPlanner::computeCurrentCost to obtain the current cost.
-  * @return 2D Cost / error vector [nh cost, backward drive dir cost]^T
-  */     
-  ErrorVector& getError()
-  {
-    computeError();
-    return _error;
-  }
-  
+
   /**
    * @brief Read values from input stream
    */  	
@@ -138,21 +123,6 @@ template <int D, typename E, typename VertexXi, typename VertexXj>
 class BaseTebBinaryEdge : public g2o::BaseBinaryEdge<D, E, VertexXi, VertexXj>
 {
 public:
-    
-  using typename g2o::BaseBinaryEdge<D, E, VertexXi, VertexXj>::ErrorVector;
-  using g2o::BaseBinaryEdge<D, E, VertexXi, VertexXj>::computeError;
-
-  /**
-  * @brief Compute and return error / cost value.
-  * 
-  * This method is called by TebOptimalPlanner::computeCurrentCost to obtain the current cost.
-  * @return 2D Cost / error vector [nh cost, backward drive dir cost]^T
-  */     
-  ErrorVector& getError()
-  {
-    computeError();
-    return _error;
-  }
   
   /**
    * @brief Read values from input stream
@@ -207,31 +177,7 @@ template <int D, typename E>
 class BaseTebMultiEdge : public g2o::BaseMultiEdge<D, E>
 {
 public:
-  
-  using typename g2o::BaseMultiEdge<D, E>::ErrorVector;
-  using g2o::BaseMultiEdge<D, E>::computeError;
-    
-  // Overwrites resize() from the parent class
-  virtual void resize(size_t size)
-  {
-      g2o::BaseMultiEdge<D, E>::resize(size);
-      
-      for(std::size_t i=0; i<_vertices.size(); ++i)
-        _vertices[i] = NULL;
-  }
 
-  /**
-  * @brief Compute and return error / cost value.
-  * 
-  * This method is called by TebOptimalPlanner::computeCurrentCost to obtain the current cost.
-  * @return 2D Cost / error vector [nh cost, backward drive dir cost]^T
-  */     
-  ErrorVector& getError()
-  {
-    computeError();
-    return _error;
-  }
-  
   /**
    * @brief Read values from input stream
    */  	


### PR DESCRIPTION
PR cleans up the code a little bit:
1. remove unused getError methods and the definition imported by it (I suppose this was used some time ago and left here)
2. remove the overwrite of resize, since g2o sets the all vertices already to 0. see 
https://github.com/RainerKuemmerle/g2o/blob/c64f79af4b7308a0505a05831f46e0dffb9a0c45/g2o/core/hyper_graph.cpp#L70
3. add a config-interface, so we can reuse it in all base-edge classes (reduces the copy and paste code)