### PR TITLE
Handle empty polygon in customObstacle callback

### DIFF
--- a/src/test_optim_node.cpp
+++ b/src/test_optim_node.cpp
@@ -269,6 +269,11 @@ void CB_customObstacle(const costmap_converter::ObstacleArrayMsg::ConstPtr& obst
                                                             obst_msg->obstacles.at(i).radius )));
       }
     }
+    else if (obst_msg->obstacles.at(i).polygon.points.empty())
+    {
+      ROS_WARN("Invalid custom obstacle received. List of polygon vertices is empty. Skipping...");
+      continue;
+    }
     else
     {
       PolygonObstacle* polyobst = new PolygonObstacle;


### PR DESCRIPTION
This prevents the planner from crashing when publishing an empty polygon in an ObstacleMsg to the `test_optim_node`.