### PR TITLE
Missing usage of free_goal_vel parameter fix

### DIFF
--- a/include/teb_local_planner/graph_search.h
+++ b/include/teb_local_planner/graph_search.h
@@ -136,6 +136,7 @@ protected:
    * @param start_orientation Orientation of the first trajectory pose, required to initialize the trajectory/TEB
    * @param goal_orientation Orientation of the goal trajectory pose, required to initialize the trajectory/TEB
    * @param start_velocity start velocity (optional)
+   * @param free_goal_vel if \c true, a nonzero final velocity at the goal pose is allowed, otherwise the final velocity will be zero (default: false)
    */
   void DepthFirst(HcGraph& g, std::vector<HcGraphVertexType>& visited, const HcGraphVertexType& goal, double start_orientation, double goal_orientation, const geometry_msgs::Twist* start_velocity, bool free_goal_vel = false);
 

--- a/include/teb_local_planner/graph_search.h
+++ b/include/teb_local_planner/graph_search.h
@@ -108,7 +108,7 @@ class GraphSearchInterface
 {
 public:
 
-  virtual void createGraph(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, double obstacle_heading_threshold, const geometry_msgs::Twist* start_velocity) = 0;
+  virtual void createGraph(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, double obstacle_heading_threshold, const geometry_msgs::Twist* start_velocity, bool free_goal_vel = false) = 0;
 
   /**
    * @brief Clear any existing graph of the homotopy class search
@@ -137,7 +137,7 @@ protected:
    * @param goal_orientation Orientation of the goal trajectory pose, required to initialize the trajectory/TEB
    * @param start_velocity start velocity (optional)
    */
-  void DepthFirst(HcGraph& g, std::vector<HcGraphVertexType>& visited, const HcGraphVertexType& goal, double start_orientation, double goal_orientation, const geometry_msgs::Twist* start_velocity);
+  void DepthFirst(HcGraph& g, std::vector<HcGraphVertexType>& visited, const HcGraphVertexType& goal, double start_orientation, double goal_orientation, const geometry_msgs::Twist* start_velocity, bool free_goal_vel = false);
 
 
 protected:
@@ -171,8 +171,9 @@ public:
    * @param dist_to_obst Allowed distance to obstacles: if not satisfying, the path will be rejected (note, this is not the distance used for optimization).
    * @param obstacle_heading_threshold Value of the normalized scalar product between obstacle heading and goal heading in order to take them (obstacles) into account [0,1]
    * @param start_velocity start velocity (optional)
+   * @param free_goal_vel if \c true, a nonzero final velocity at the goal pose is allowed, otherwise the final velocity will be zero (default: false)
    */
-  virtual void createGraph(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, double obstacle_heading_threshold, const geometry_msgs::Twist* start_velocity);
+  virtual void createGraph(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, double obstacle_heading_threshold, const geometry_msgs::Twist* start_velocity, bool free_goal_vel = false);
 };
 
 
@@ -201,8 +202,9 @@ public:
    * @param no_samples number of random samples
    * @param obstacle_heading_threshold Value of the normalized scalar product between obstacle heading and goal heading in order to take them (obstacles) into account [0,1]
    * @param start_velocity start velocity (optional)
+   * @param free_goal_vel if \c true, a nonzero final velocity at the goal pose is allowed, otherwise the final velocity will be zero (default: false)
    */
-  virtual void createGraph(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, double obstacle_heading_threshold, const geometry_msgs::Twist* start_velocity);
+  virtual void createGraph(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, double obstacle_heading_threshold, const geometry_msgs::Twist* start_velocity, bool free_goal_vel = false);
 
 private:
     boost::random::mt19937 rnd_generator_; //!< Random number generator used by createProbRoadmapGraph to sample graph keypoints.

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -295,6 +295,7 @@ public:
    * @param start_orientation Orientation of the first pose of the trajectory (optional, otherwise use goal heading)
    * @param goal_orientation Orientation of the last pose of the trajectory (optional, otherwise use goal heading)
    * @param start_velocity start velocity (optional)
+   * @param free_goal_vel if \c true, a nonzero final velocity at the goal pose is allowed, otherwise the final velocity will be zero (default: false)
    * @tparam BidirIter Bidirectional iterator type
    * @tparam Fun unyary function that transforms the dereferenced iterator into an Eigen::Vector2d
    * @return Shared pointer to the newly created teb optimal planner

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -281,8 +281,9 @@ public:
    * @param goal Goal pose (e.g. robot's goal)
    * @param dist_to_obst Allowed distance to obstacles: if not satisfying, the path will be rejected (note, this is not the distance used for optimization).
    * @param @param start_velocity start velocity (optional)
+   * @param free_goal_vel if \c true, a nonzero final velocity at the goal pose is allowed, otherwise the final velocity will be zero (default: false)
    */
-  void exploreEquivalenceClassesAndInitTebs(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, const geometry_msgs::Twist* start_vel);
+  void exploreEquivalenceClassesAndInitTebs(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, const geometry_msgs::Twist* start_vel, bool free_goal_vel = false);
 
   /**
    * @brief Add a new Teb to the internal trajectory container, if this teb constitutes a new equivalence class. Initialize it using a generic 2D reference path
@@ -299,24 +300,26 @@ public:
    * @return Shared pointer to the newly created teb optimal planner
    */
   template<typename BidirIter, typename Fun>
-  TebOptimalPlannerPtr addAndInitNewTeb(BidirIter path_start, BidirIter path_end, Fun fun_position, double start_orientation, double goal_orientation, const geometry_msgs::Twist* start_velocity);
+  TebOptimalPlannerPtr addAndInitNewTeb(BidirIter path_start, BidirIter path_end, Fun fun_position, double start_orientation, double goal_orientation, const geometry_msgs::Twist* start_velocity, bool free_goal_vel = false);
 
   /**
    * @brief Add a new Teb to the internal trajectory container, if this teb constitutes a new equivalence class. Initialize it with a simple straight line between a given start and goal
    * @param start start pose
    * @param goal goal pose
    * @param start_velocity start velocity (optional)
+   * @param free_goal_vel if \c true, a nonzero final velocity at the goal pose is allowed, otherwise the final velocity will be zero (default: false)
    * @return Shared pointer to the newly created teb optimal planner
    */
-  TebOptimalPlannerPtr addAndInitNewTeb(const PoseSE2& start, const PoseSE2& goal, const geometry_msgs::Twist* start_velocity);
+  TebOptimalPlannerPtr addAndInitNewTeb(const PoseSE2& start, const PoseSE2& goal, const geometry_msgs::Twist* start_velocity, bool free_goal_vel = false);
 
   /**
    * @brief Add a new Teb to the internal trajectory container , if this teb constitutes a new equivalence class. Initialize it using a PoseStamped container
    * @param initial_plan container of poses (start and goal orientation should be valid!)
    * @param start_velocity start velocity (optional)
+   * @param free_goal_vel if \c true, a nonzero final velocity at the goal pose is allowed, otherwise the final velocity will be zero (default: false)
    * @return Shared pointer to the newly created teb optimal planner
    */
-  TebOptimalPlannerPtr addAndInitNewTeb(const std::vector<geometry_msgs::PoseStamped>& initial_plan, const geometry_msgs::Twist* start_velocity);
+  TebOptimalPlannerPtr addAndInitNewTeb(const std::vector<geometry_msgs::PoseStamped>& initial_plan, const geometry_msgs::Twist* start_velocity, bool free_goal_vel = false);
 
   /**
    * @brief Update TEBs with new pose, goal and current velocity.

--- a/include/teb_local_planner/homotopy_class_planner.hpp
+++ b/include/teb_local_planner/homotopy_class_planner.hpp
@@ -63,7 +63,7 @@ EquivalenceClassPtr HomotopyClassPlanner::calculateEquivalenceClass(BidirIter pa
 
 
 template<typename BidirIter, typename Fun>
-TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(BidirIter path_start, BidirIter path_end, Fun fun_position, double start_orientation, double goal_orientation, const geometry_msgs::Twist* start_velocity)
+TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(BidirIter path_start, BidirIter path_end, Fun fun_position, double start_orientation, double goal_orientation, const geometry_msgs::Twist* start_velocity, bool free_goal_vel)
 {
   TebOptimalPlannerPtr candidate = TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, robot_model_));
 
@@ -76,6 +76,10 @@ TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(BidirIter path_start
 
   EquivalenceClassPtr H = calculateEquivalenceClass(candidate->teb().poses().begin(), candidate->teb().poses().end(), getCplxFromVertexPosePtr, obstacles_,
                                                     candidate->teb().timediffs().begin(), candidate->teb().timediffs().end());
+
+  
+  if (free_goal_vel)
+    candidate->setVelocityGoalFree();
 
   if(addEquivalenceClassIfNew(H))
   {

--- a/src/graph_search.cpp
+++ b/src/graph_search.cpp
@@ -43,7 +43,7 @@ namespace teb_local_planner
 {
 
 void GraphSearchInterface::DepthFirst(HcGraph& g, std::vector<HcGraphVertexType>& visited, const HcGraphVertexType& goal, double start_orientation,
-                                      double goal_orientation, const geometry_msgs::Twist* start_velocity)
+                                      double goal_orientation, const geometry_msgs::Twist* start_velocity, bool free_goal_vel)
 {
   // see http://www.technical-recipes.com/2011/a-recursive-algorithm-to-find-all-paths-between-two-given-nodes/ for details on finding all simple paths
 
@@ -65,7 +65,7 @@ void GraphSearchInterface::DepthFirst(HcGraph& g, std::vector<HcGraphVertexType>
 
       // Add new TEB, if this path belongs to a new homotopy class
       hcp_->addAndInitNewTeb(visited.begin(), visited.end(), boost::bind(getVector2dFromHcGraph, _1, boost::cref(graph_)),
-                             start_orientation, goal_orientation, start_velocity);
+                             start_orientation, goal_orientation, start_velocity, free_goal_vel);
 
       visited.pop_back();
       break;
@@ -82,7 +82,7 @@ void GraphSearchInterface::DepthFirst(HcGraph& g, std::vector<HcGraphVertexType>
     visited.push_back(*it);
 
     // recursion step
-    DepthFirst(g, visited, goal, start_orientation, goal_orientation, start_velocity);
+    DepthFirst(g, visited, goal, start_orientation, goal_orientation, start_velocity, free_goal_vel);
 
     visited.pop_back();
   }
@@ -90,7 +90,7 @@ void GraphSearchInterface::DepthFirst(HcGraph& g, std::vector<HcGraphVertexType>
 
 
 
-void lrKeyPointGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, double obstacle_heading_threshold, const geometry_msgs::Twist* start_velocity)
+void lrKeyPointGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, double obstacle_heading_threshold, const geometry_msgs::Twist* start_velocity, bool free_goal_vel)
 {
   // Clear existing graph and paths
   clearGraph();
@@ -105,7 +105,7 @@ void lrKeyPointGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, dou
     if (hcp_->getTrajectoryContainer().empty())
     {
       ROS_INFO("HomotopyClassPlanner::createProbRoadmapGraph(): Initializing a small straight line to just correct orientation errors.");
-      hcp_->addAndInitNewTeb(start, goal, start_velocity);
+      hcp_->addAndInitNewTeb(start, goal, start_velocity, free_goal_vel);
     }
     return;
   }
@@ -212,12 +212,12 @@ void lrKeyPointGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, dou
   // Find all paths between start and goal!
   std::vector<HcGraphVertexType> visited;
   visited.push_back(start_vtx);
-  DepthFirst(graph_,visited,goal_vtx, start.theta(), goal.theta(), start_velocity);
+  DepthFirst(graph_,visited,goal_vtx, start.theta(), goal.theta(), start_velocity, free_goal_vel);
 }
 
 
 
-void ProbRoadmapGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, double obstacle_heading_threshold, const geometry_msgs::Twist* start_velocity)
+void ProbRoadmapGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, double obstacle_heading_threshold, const geometry_msgs::Twist* start_velocity, bool free_goal_vel)
 {
   // Clear existing graph and paths
   clearGraph();
@@ -233,7 +233,7 @@ void ProbRoadmapGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, do
     if (hcp_->getTrajectoryContainer().empty())
     {
       ROS_INFO("HomotopyClassPlanner::createProbRoadmapGraph(): Initializing a small straight line to just correct orientation errors.");
-      hcp_->addAndInitNewTeb(start, goal, start_velocity);
+      hcp_->addAndInitNewTeb(start, goal, start_velocity, free_goal_vel);
     }
     return;
   }
@@ -336,7 +336,7 @@ void ProbRoadmapGraph::createGraph(const PoseSE2& start, const PoseSE2& goal, do
   /// Find all paths between start and goal!
   std::vector<HcGraphVertexType> visited;
   visited.push_back(start_vtx);
-  DepthFirst(graph_,visited,goal_vtx, start.theta(), goal.theta(), start_velocity);
+  DepthFirst(graph_,visited,goal_vtx, start.theta(), goal.theta(), start_velocity, free_goal_vel);
 }
 
 } // end namespace

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -419,7 +419,7 @@ int HomotopyClassPlanner::numTebsInBestTebClass() const
   return count;
 }
 
-TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const std::vector<geometry_msgs::PoseStamped>& initial_plan, const geometry_msgs::Twist* start_velocity)
+TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const std::vector<geometry_msgs::PoseStamped>& initial_plan, const geometry_msgs::Twist* start_velocity, bool free_goal_vel)
 {
   if(tebs_.size() >= cfg_->hcp.max_number_classes)
     return TebOptimalPlannerPtr();

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -120,7 +120,7 @@ bool HomotopyClassPlanner::plan(const PoseSE2& start, const PoseSE2& goal, const
   updateAllTEBs(&start, &goal, start_vel);
 
   // Init new TEBs based on newly explored homotopy classes
-  exploreEquivalenceClassesAndInitTebs(start, goal, cfg_->obstacles.min_obstacle_dist, start_vel);
+  exploreEquivalenceClassesAndInitTebs(start, goal, cfg_->obstacles.min_obstacle_dist, start_vel, free_goal_vel);
   // update via-points if activated
   updateReferenceTrajectoryViaPoints(cfg_->hcp.viapoints_all_candidates);
   // Optimize all trajectories in alternative homotopy classes
@@ -342,7 +342,7 @@ void HomotopyClassPlanner::updateReferenceTrajectoryViaPoints(bool all_trajector
 }
 
 
-void HomotopyClassPlanner::exploreEquivalenceClassesAndInitTebs(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, const geometry_msgs::Twist* start_vel)
+void HomotopyClassPlanner::exploreEquivalenceClassesAndInitTebs(const PoseSE2& start, const PoseSE2& goal, double dist_to_obst, const geometry_msgs::Twist* start_vel, bool free_goal_vel)
 {
   // first process old trajectories
   renewAndAnalyzeOldTebs(cfg_->hcp.delete_detours_backwards);
@@ -351,7 +351,7 @@ void HomotopyClassPlanner::exploreEquivalenceClassesAndInitTebs(const PoseSE2& s
   // inject initial plan if available and not yet captured
   if (initial_plan_)
   {
-    initial_plan_teb_ = addAndInitNewTeb(*initial_plan_, start_vel);
+    initial_plan_teb_ = addAndInitNewTeb(*initial_plan_, start_vel, free_goal_vel);
   }
   else
   {
@@ -360,11 +360,11 @@ void HomotopyClassPlanner::exploreEquivalenceClassesAndInitTebs(const PoseSE2& s
   }
 
   // now explore new homotopy classes and initialize tebs if new ones are found. The appropriate createGraph method is chosen via polymorphism.
-  graph_search_->createGraph(start,goal,dist_to_obst,cfg_->hcp.obstacle_heading_threshold, start_vel);
+  graph_search_->createGraph(start,goal,dist_to_obst,cfg_->hcp.obstacle_heading_threshold, start_vel, free_goal_vel);
 }
 
 
-TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const PoseSE2& start, const PoseSE2& goal, const geometry_msgs::Twist* start_velocity)
+TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const PoseSE2& start, const PoseSE2& goal, const geometry_msgs::Twist* start_velocity, bool free_goal_vel)
 {
   if(tebs_.size() >= cfg_->hcp.max_number_classes)
     return TebOptimalPlannerPtr();
@@ -377,6 +377,9 @@ TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const PoseSE2& start
 
   EquivalenceClassPtr H = calculateEquivalenceClass(candidate->teb().poses().begin(), candidate->teb().poses().end(), getCplxFromVertexPosePtr, obstacles_,
                                                     candidate->teb().timediffs().begin(), candidate->teb().timediffs().end());
+
+  if (free_goal_vel)
+    candidate->setVelocityGoalFree(); 
 
   if(addEquivalenceClassIfNew(H))
   {
@@ -427,6 +430,9 @@ TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const std::vector<ge
 
   if (start_velocity)
     candidate->setVelocityStart(*start_velocity);
+
+  if (free_goal_vel)
+    candidate->setVelocityGoalFree();
 
   // store the h signature of the initial plan to enable searching a matching teb later.
   initial_plan_eq_class_ = calculateEquivalenceClass(candidate->teb().poses().begin(), candidate->teb().poses().end(), getCplxFromVertexPosePtr, obstacles_,


### PR DESCRIPTION
**Note**: As discussed in [Pull request 229](https://github.com/rst-tu-dortmund/teb_local_planner/pull/229), new pull request for melodic-devel is generated here similar to kinetic-devel branch

Hello Sir,

I have been working on teb local planner package since the past few months and have found it very useful to carry on my research in the area of Motion Planning. While working on this planner, the parameter free_goal_vel was required, but I wasn’t getting the desired output when this parameter was set to true (Refer: Observations before the code fix). 

### Parameter definition

`~<name>/free_goal_vel`(bool, default: false)
Remove the goal velocity constraint such that the robot can arrive at the goal with maximum speed

### Test scenario in Rviz

A 2D-road scenario is created in Rviz. It consists of road borders and car-like actor as obstacles. Robot footprint is polygonal. 

#### Observations before the code fix:

##### free_goal_vel parameter set to false

![uncorrected_free_goal_vel_false](https://user-images.githubusercontent.com/51834528/93685781-0b5d2d80-fab2-11ea-8dc7-07e3ea139585.png)
Figure legend:- green: local plan, red: Obstacles, red arrows: teb poses

##### free_goal_vel parameter set to true

![uncorrected_free_goal_vel_true](https://user-images.githubusercontent.com/51834528/93685789-1748ef80-fab2-11ea-9ee7-0738c9dfcf55.png)
Figure legend:- green: local plan, red: Obstacles, red arrows: teb poses

As we can see in the above figures, although the parameter free_goal_vel is set to true, the poses are reaching a zero velocity near the goal. There seems to be no effect after setting this parameter to true.

After going through your code, I found some potential fixes related to the usage of this parameter:

### **Fix 1:**

**Files:**

1. src/homotopy_class_planner.cpp

- Although the parameter free_goal_vel is passed as parameter to the plan() function, it was never used in the function definition. After fixing this missing usage, I got the desired results. Please refer Observations after the code fix regarding the same.


### **Fix 2:**

**Files:**

1. include/teb_local_planner/graph_search.h
2. include/teb_local_planner/homotopy_class_planner.h
3. include/teb_local_planner/homotopy_class_planner.hpp
4. src/graph_search.cpp

- The function declarations are appended with an additional parameter  free_goal_vel (with its default value as false in the argument list) wherever necessary
- The function setVelocityGoalFree() is called at appropriate places based on the value of the free_goal_vel parameter

### Observations after the code fix:

##### free_goal_vel parameter set to false

![free_goal_vel_false](https://user-images.githubusercontent.com/51834528/93685794-2039c100-fab2-11ea-98bc-404efdd1f4f2.png)
Figure legend:- green: local plan, red: Obstacles, red arrows: teb poses

##### free_goal_vel parameter set to true

![free_goal_vel_true](https://user-images.githubusercontent.com/51834528/93685805-26c83880-fab2-11ea-8097-0ec3e82ba46d.png)
Figure legend:- green: local plan, red: Obstacles, red arrows: teb poses

In the figures above, once the free_goal_vel parameter is set to true, it can be observed that the teb poses now reach the goal with a non-zero velocity. 

I hope my request will be concurred.


