### PR TITLE
fix segfault at robot-model update

### DIFF
--- a/include/teb_local_planner/g2o_types/edge_dynamic_obstacle.h
+++ b/include/teb_local_planner/g2o_types/edge_dynamic_obstacle.h
@@ -80,7 +80,7 @@ public:
   }
   
   /**
-   * @brief Construct edge and specify the time for its associated pose (neccessary for computeError).
+   * @brief Construct edge and specify the time for its associated pose (necessary for computeError).
    * @param t_ Estimated time until current pose is reached
    */      
   EdgeDynamicObstacle(double t) : t_(t)
@@ -92,10 +92,10 @@ public:
    */   
   void computeError()
   {
-    ROS_ASSERT_MSG(cfg_ && _measurement && robot_model_, "You must call setTebConfig(), setObstacle() and setRobotModel() on EdgeDynamicObstacle()");
+    ROS_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setObstacle() on EdgeDynamicObstacle()");
     const VertexPose* bandpt = static_cast<const VertexPose*>(_vertices[0]);
     
-    double dist = robot_model_->estimateSpatioTemporalDistance(bandpt->pose(), _measurement, t_);
+    double dist = cfg_->robot_model->estimateSpatioTemporalDistance(bandpt->pose(), _measurement, t_);
 
     _error[0] = penaltyBoundFromBelow(dist, cfg_->obstacles.min_obstacle_dist, cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundFromBelow(dist, cfg_->obstacles.dynamic_obstacle_inflation_dist, 0.0);
@@ -114,39 +114,25 @@ public:
   }
   
   /**
-   * @brief Set pointer to the robot model
-   * @param robot_model Robot model required for distance calculation
-   */
-  void setRobotModel(const BaseRobotFootprintModel* robot_model)
-  {
-    robot_model_ = robot_model;
-  }
-
-  /**
    * @brief Set all parameters at once
    * @param cfg TebConfig class
-   * @param robot_model Robot model required for distance calculation
    * @param obstacle 2D position vector containing the position of the obstacle
    */
-  void setParameters(const TebConfig& cfg, const BaseRobotFootprintModel* robot_model, const Obstacle* obstacle)
+  void setParameters(const TebConfig& cfg, const Obstacle* obstacle)
   {
     cfg_ = &cfg;
-    robot_model_ = robot_model;
     _measurement = obstacle;
   }
 
 protected:
   
-  const BaseRobotFootprintModel* robot_model_; //!< Store pointer to robot_model
   double t_; //!< Estimated time until current pose is reached
   
 public: 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };
-    
- 
-    
+
 
 } // end namespace
 

--- a/include/teb_local_planner/g2o_types/edge_obstacle.h
+++ b/include/teb_local_planner/g2o_types/edge_obstacle.h
@@ -84,10 +84,10 @@ public:
    */    
   void computeError()
   {
-    ROS_ASSERT_MSG(cfg_ && _measurement && robot_model_, "You must call setTebConfig(), setObstacle() and setRobotModel() on EdgeObstacle()");
+    ROS_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setObstacle() on EdgeObstacle()");
     const VertexPose* bandpt = static_cast<const VertexPose*>(_vertices[0]);
 
-    double dist = robot_model_->calculateDistance(bandpt->pose(), _measurement);
+    double dist = cfg_->robot_model->calculateDistance(bandpt->pose(), _measurement);
 
     // Original obstacle cost.
     _error[0] = penaltyBoundFromBelow(dist, cfg_->obstacles.min_obstacle_dist, cfg_->optim.penalty_epsilon);
@@ -160,34 +160,17 @@ public:
   }
     
   /**
-   * @brief Set pointer to the robot model 
-   * @param robot_model Robot model required for distance calculation
-   */ 
-  void setRobotModel(const BaseRobotFootprintModel* robot_model)
-  {
-    robot_model_ = robot_model;
-  }
-    
-  /**
    * @brief Set all parameters at once
    * @param cfg TebConfig class
-   * @param robot_model Robot model required for distance calculation
    * @param obstacle 2D position vector containing the position of the obstacle
    */ 
-  void setParameters(const TebConfig& cfg, const BaseRobotFootprintModel* robot_model, const Obstacle* obstacle)
+  void setParameters(const TebConfig& cfg, const Obstacle* obstacle)
   {
     cfg_ = &cfg;
-    robot_model_ = robot_model;
     _measurement = obstacle;
   }
   
-protected:
-
-  const BaseRobotFootprintModel* robot_model_; //!< Store pointer to robot_model
-  
-public: 	
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
 };
   
 
@@ -223,10 +206,10 @@ public:
    */    
   void computeError()
   {
-    ROS_ASSERT_MSG(cfg_ && _measurement && robot_model_, "You must call setTebConfig(), setObstacle() and setRobotModel() on EdgeInflatedObstacle()");
+    ROS_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setObstacle() on EdgeInflatedObstacle()");
     const VertexPose* bandpt = static_cast<const VertexPose*>(_vertices[0]);
 
-    double dist = robot_model_->calculateDistance(bandpt->pose(), _measurement);
+    double dist = cfg_->robot_model->calculateDistance(bandpt->pose(), _measurement);
 
     // Original "straight line" obstacle cost. The max possible value
     // before weighting is min_obstacle_dist
@@ -257,36 +240,19 @@ public:
   {
     _measurement = obstacle;
   }
-    
-  /**
-   * @brief Set pointer to the robot model 
-   * @param robot_model Robot model required for distance calculation
-   */ 
-  void setRobotModel(const BaseRobotFootprintModel* robot_model)
-  {
-    robot_model_ = robot_model;
-  }
-    
+
   /**
    * @brief Set all parameters at once
    * @param cfg TebConfig class
-   * @param robot_model Robot model required for distance calculation
    * @param obstacle 2D position vector containing the position of the obstacle
    */ 
-  void setParameters(const TebConfig& cfg, const BaseRobotFootprintModel* robot_model, const Obstacle* obstacle)
+  void setParameters(const TebConfig& cfg, const Obstacle* obstacle)
   {
     cfg_ = &cfg;
-    robot_model_ = robot_model;
     _measurement = obstacle;
   }
   
-protected:
-
-  const BaseRobotFootprintModel* robot_model_; //!< Store pointer to robot_model
-  
-public:         
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
 };
     
 

--- a/include/teb_local_planner/g2o_types/edge_velocity_obstacle_ratio.h
+++ b/include/teb_local_planner/g2o_types/edge_velocity_obstacle_ratio.h
@@ -27,8 +27,7 @@ public:
   /**
    * @brief Construct edge.
    */
-  EdgeVelocityObstacleRatio() :
-    robot_model_(nullptr)
+  EdgeVelocityObstacleRatio()
   {
     // The three vertices are two poses and one time difference
     this->resize(3); // Since we derive from a g2o::BaseMultiEdge, set the desired number of vertices
@@ -39,7 +38,7 @@ public:
    */
   void computeError()
   {
-    ROS_ASSERT_MSG(cfg_ && _measurement && robot_model_, "You must call setTebConfig(), setObstacle() and setRobotModel() on EdgeVelocityObstacleRatio()");
+    ROS_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setObstacle() on EdgeVelocityObstacleRatio()");
     const VertexPose* conf1 = static_cast<const VertexPose*>(_vertices[0]);
     const VertexPose* conf2 = static_cast<const VertexPose*>(_vertices[1]);
     const VertexTimeDiff* deltaT = static_cast<const VertexTimeDiff*>(_vertices[2]);
@@ -59,7 +58,7 @@ public:
 
     const double omega = angle_diff / deltaT->estimate();
 
-    double dist_to_obstacle = robot_model_->calculateDistance(conf1->pose(), _measurement);
+    double dist_to_obstacle = cfg_->robot_model->calculateDistance(conf1->pose(), _measurement);
 
     double ratio;
     if (dist_to_obstacle < cfg_->obstacles.obstacle_proximity_lower_bound)
@@ -89,35 +88,18 @@ public:
   }
 
   /**
-   * @brief Set pointer to the robot model
-   * @param robot_model Robot model required for distance calculation
-   */
-  void setRobotModel(const BaseRobotFootprintModel* robot_model)
-  {
-    robot_model_ = robot_model;
-  }
-
-  /**
    * @brief Set all parameters at once
    * @param cfg TebConfig class
-   * @param robot_model Robot model required for distance calculation
    * @param obstacle 2D position vector containing the position of the obstacle
    */
-  void setParameters(const TebConfig& cfg, const BaseRobotFootprintModel* robot_model, const Obstacle* obstacle)
+  void setParameters(const TebConfig& cfg, const Obstacle* obstacle)
   {
     cfg_ = &cfg;
-    robot_model_ = robot_model;
     _measurement = obstacle;
   }
 
-protected:
-
-  const BaseRobotFootprintModel* robot_model_; //!< Store pointer to robot_model
-
-public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
 };
-
 
 } // end namespace

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -120,11 +120,10 @@ public:
    * @brief Construct and initialize the HomotopyClassPlanner
    * @param cfg Const reference to the TebConfig class for internal parameters
    * @param obstacles Container storing all relevant obstacles (see Obstacle)
-   * @param robot_model Shared pointer to the robot shape model used for optimization (optional)
    * @param visualization Shared pointer to the TebVisualization class (optional)
    * @param via_points Container storing via-points (optional)
    */
-  HomotopyClassPlanner(const TebConfig& cfg, ObstContainer* obstacles = NULL, RobotFootprintModelPtr robot_model = boost::make_shared<PointRobotFootprint>(),
+  HomotopyClassPlanner(const TebConfig& cfg, ObstContainer* obstacles = NULL,
                        TebVisualizationPtr visualization = TebVisualizationPtr(), const ViaPointContainer* via_points = NULL);
 
   /**
@@ -136,15 +135,12 @@ public:
    * @brief Initialize the HomotopyClassPlanner
    * @param cfg Const reference to the TebConfig class for internal parameters
    * @param obstacles Container storing all relevant obstacles (see Obstacle)
-   * @param robot_model Shared pointer to the robot shape model used for optimization (optional)
    * @param visualization Shared pointer to the TebVisualization class (optional)
    * @param via_points Container storing via-points (optional)
    */
-  void initialize(const TebConfig& cfg, ObstContainer* obstacles = NULL, RobotFootprintModelPtr robot_model = boost::make_shared<PointRobotFootprint>(),
+  void initialize(const TebConfig& cfg, ObstContainer* obstacles = NULL,
                   TebVisualizationPtr visualization = TebVisualizationPtr(), const ViaPointContainer* via_points = NULL);
 
-
-  void updateRobotModel(RobotFootprintModelPtr robot_model );
 
   /** @name Plan a trajectory */
   //@{
@@ -547,7 +543,6 @@ protected:
   TebVisualizationPtr visualization_; //!< Instance of the visualization class (local/global plan, obstacles, ...)
   TebOptimalPlannerPtr best_teb_; //!< Store the current best teb.
   EquivalenceClassPtr best_teb_eq_class_; //!< Store the equivalence class of the current best teb
-  RobotFootprintModelPtr robot_model_; //!< Robot model shared instance
 
   const std::vector<geometry_msgs::PoseStamped>* initial_plan_; //!< Store the initial plan if available for a better trajectory initialization
   EquivalenceClassPtr initial_plan_eq_class_; //!< Store the equivalence class of the initial plan

--- a/include/teb_local_planner/homotopy_class_planner.hpp
+++ b/include/teb_local_planner/homotopy_class_planner.hpp
@@ -65,7 +65,7 @@ EquivalenceClassPtr HomotopyClassPlanner::calculateEquivalenceClass(BidirIter pa
 template<typename BidirIter, typename Fun>
 TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(BidirIter path_start, BidirIter path_end, Fun fun_position, double start_orientation, double goal_orientation, const geometry_msgs::Twist* start_velocity)
 {
-  TebOptimalPlannerPtr candidate = TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, robot_model_));
+  TebOptimalPlannerPtr candidate = TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_));
 
   candidate->teb().initTrajectoryToGoal(path_start, path_end, fun_position, cfg_->robot.max_vel_x, cfg_->robot.max_vel_theta,
                                  cfg_->robot.acc_lim_x, cfg_->robot.acc_lim_theta, start_orientation, goal_orientation, cfg_->trajectory.min_samples,

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -110,11 +110,10 @@ public:
    * @brief Construct and initialize the TEB optimal planner.
    * @param cfg Const reference to the TebConfig class for internal parameters
    * @param obstacles Container storing all relevant obstacles (see Obstacle)
-   * @param robot_model Shared pointer to the robot shape model used for optimization (optional)
    * @param visual Shared pointer to the TebVisualization class (optional)
    * @param via_points Container storing via-points (optional)
    */
-  TebOptimalPlanner(const TebConfig& cfg, ObstContainer* obstacles = NULL, RobotFootprintModelPtr robot_model = boost::make_shared<PointRobotFootprint>(),
+  TebOptimalPlanner(const TebConfig& cfg, ObstContainer* obstacles = NULL,
                     TebVisualizationPtr visual = TebVisualizationPtr(), const ViaPointContainer* via_points = NULL);
   
   /**
@@ -126,18 +125,12 @@ public:
     * @brief Initializes the optimal planner
     * @param cfg Const reference to the TebConfig class for internal parameters
     * @param obstacles Container storing all relevant obstacles (see Obstacle)
-    * @param robot_model Shared pointer to the robot shape model used for optimization (optional)
     * @param visual Shared pointer to the TebVisualization class (optional)
     * @param via_points Container storing via-points (optional)
     */
-  void initialize(const TebConfig& cfg, ObstContainer* obstacles = NULL, RobotFootprintModelPtr robot_model = boost::make_shared<PointRobotFootprint>(),
+  void initialize(const TebConfig& cfg, ObstContainer* obstacles = NULL,
                   TebVisualizationPtr visual = TebVisualizationPtr(), const ViaPointContainer* via_points = NULL);
-  
-  /**
-    * @param robot_model Shared pointer to the robot shape model used for optimization (optional)
-    */
-  void updateRobotModel(RobotFootprintModelPtr robot_model );
-  
+
   /** @name Plan a trajectory  */
   //@{
   
@@ -685,7 +678,6 @@ protected:
   // internal objects (memory management owned)
   TebVisualizationPtr visualization_; //!< Instance of the visualization class
   TimedElasticBand teb_; //!< Actual trajectory object
-  RobotFootprintModelPtr robot_model_; //!< Robot model
   boost::shared_ptr<g2o::SparseOptimizer> optimizer_; //!< g2o optimizer for trajectory optimization
   std::pair<bool, geometry_msgs::Twist> vel_start_; //!< Store the initial velocity at the start pose
   std::pair<bool, geometry_msgs::Twist> vel_goal_; //!< Store the final velocity at the goal pose

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -45,6 +45,7 @@
 #include <Eigen/StdVector>
 
 #include <teb_local_planner/TebLocalPlannerReconfigureConfig.h>
+#include <teb_local_planner/robot_footprint_model.h>
 
 
 // Definitions
@@ -64,6 +65,8 @@ public:
 
   std::string odom_topic; //!< Topic name of the odometry message, provided by the robot driver or simulator
   std::string map_frame; //!< Global planning frame
+
+  RobotFootprintModelPtr robot_model; //!< model of the robot's footprint
 
   //! Trajectory related parameters
   struct Trajectory
@@ -237,6 +240,7 @@ public:
 
     odom_topic = "odom";
     map_frame = "odom";
+    robot_model = boost::make_shared<PointRobotFootprint>();
 
     // Trajectory
 

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -43,27 +43,26 @@
 namespace teb_local_planner
 {
 
-HomotopyClassPlanner::HomotopyClassPlanner() : cfg_(NULL), obstacles_(NULL), via_points_(NULL), robot_model_(new PointRobotFootprint()), initial_plan_(NULL), initialized_(false)
+HomotopyClassPlanner::HomotopyClassPlanner() : cfg_(NULL), obstacles_(NULL), via_points_(NULL), initial_plan_(NULL), initialized_(false)
 {
 }
 
-HomotopyClassPlanner::HomotopyClassPlanner(const TebConfig& cfg, ObstContainer* obstacles, RobotFootprintModelPtr robot_model,
+HomotopyClassPlanner::HomotopyClassPlanner(const TebConfig& cfg, ObstContainer* obstacles,
                                            TebVisualizationPtr visual, const ViaPointContainer* via_points) : initial_plan_(NULL)
 {
-  initialize(cfg, obstacles, robot_model, visual, via_points);
+  initialize(cfg, obstacles, visual, via_points);
 }
 
 HomotopyClassPlanner::~HomotopyClassPlanner()
 {
 }
 
-void HomotopyClassPlanner::initialize(const TebConfig& cfg, ObstContainer* obstacles, RobotFootprintModelPtr robot_model,
+void HomotopyClassPlanner::initialize(const TebConfig& cfg, ObstContainer* obstacles,
                                       TebVisualizationPtr visual, const ViaPointContainer* via_points)
 {
   cfg_ = &cfg;
   obstacles_ = obstacles;
   via_points_ = via_points;
-  robot_model_ = robot_model;
 
   if (cfg_->hcp.simple_exploration)
     graph_search_ = boost::shared_ptr<GraphSearchInterface>(new lrKeyPointGraph(*cfg_, this));
@@ -78,17 +77,10 @@ void HomotopyClassPlanner::initialize(const TebConfig& cfg, ObstContainer* obsta
   setVisualization(visual);
 }
 
-void HomotopyClassPlanner::updateRobotModel(RobotFootprintModelPtr robot_model )
-{
-  robot_model_ = robot_model;
-}
-
 void HomotopyClassPlanner::setVisualization(TebVisualizationPtr visualization)
 {
   visualization_ = visualization;
 }
-
-
 
 bool HomotopyClassPlanner::plan(const std::vector<geometry_msgs::PoseStamped>& initial_plan, const geometry_msgs::Twist* start_vel, bool free_goal_vel)
 {
@@ -167,7 +159,7 @@ void HomotopyClassPlanner::visualize()
       visualization_->publishLocalPlanAndPoses(best_teb->teb());
 
       if (best_teb->teb().sizePoses() > 0) //TODO maybe store current pose (start) within plan method as class field.
-        visualization_->publishRobotFootprintModel(best_teb->teb().Pose(0), *robot_model_);
+        visualization_->publishRobotFootprintModel(best_teb->teb().Pose(0), *cfg_->robot_model);
 
       // feedback message
       if (cfg_->trajectory.publish_feedback)
@@ -368,7 +360,7 @@ TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const PoseSE2& start
 {
   if(tebs_.size() >= cfg_->hcp.max_number_classes)
     return TebOptimalPlannerPtr();
-  TebOptimalPlannerPtr candidate =  TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, robot_model_, visualization_));
+  TebOptimalPlannerPtr candidate =  TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, visualization_));
 
   candidate->teb().initTrajectoryToGoal(start, goal, 0, cfg_->robot.max_vel_x, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);
 
@@ -420,7 +412,7 @@ TebOptimalPlannerPtr HomotopyClassPlanner::addAndInitNewTeb(const std::vector<ge
 {
   if(tebs_.size() >= cfg_->hcp.max_number_classes)
     return TebOptimalPlannerPtr();
-  TebOptimalPlannerPtr candidate = TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, robot_model_, visualization_));
+  TebOptimalPlannerPtr candidate = TebOptimalPlannerPtr( new TebOptimalPlanner(*cfg_, obstacles_, visualization_));
 
   candidate->teb().initTrajectoryToGoal(initial_plan, cfg_->robot.max_vel_x, cfg_->robot.max_vel_theta,
     cfg_->trajectory.global_plan_overwrite_orientation, cfg_->trajectory.min_samples, cfg_->trajectory.allow_init_with_backwards_motion);

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -60,13 +60,13 @@ namespace teb_local_planner
 // ============== Implementation ===================
 
 TebOptimalPlanner::TebOptimalPlanner() : cfg_(NULL), obstacles_(NULL), via_points_(NULL), cost_(HUGE_VAL), prefer_rotdir_(RotType::none),
-                                         robot_model_(new PointRobotFootprint()), initialized_(false), optimized_(false)
+                                         initialized_(false), optimized_(false)
 {    
 }
   
-TebOptimalPlanner::TebOptimalPlanner(const TebConfig& cfg, ObstContainer* obstacles, RobotFootprintModelPtr robot_model, TebVisualizationPtr visual, const ViaPointContainer* via_points)
-{    
-  initialize(cfg, obstacles, robot_model, visual, via_points);
+TebOptimalPlanner::TebOptimalPlanner(const TebConfig& cfg, ObstContainer* obstacles, TebVisualizationPtr visual, const ViaPointContainer* via_points)
+{
+  initialize(cfg, obstacles, visual, via_points);
 }
 
 TebOptimalPlanner::~TebOptimalPlanner()
@@ -79,19 +79,13 @@ TebOptimalPlanner::~TebOptimalPlanner()
   //g2o::HyperGraphActionLibrary::destroy();
 }
 
-void TebOptimalPlanner::updateRobotModel(RobotFootprintModelPtr robot_model)
-{
-  robot_model_ = robot_model;
-}
-
-void TebOptimalPlanner::initialize(const TebConfig& cfg, ObstContainer* obstacles, RobotFootprintModelPtr robot_model, TebVisualizationPtr visual, const ViaPointContainer* via_points)
+void TebOptimalPlanner::initialize(const TebConfig& cfg, ObstContainer* obstacles, TebVisualizationPtr visual, const ViaPointContainer* via_points)
 {    
   // init optimizer (set solver and block ordering settings)
   optimizer_ = initOptimizer();
   
   cfg_ = &cfg;
   obstacles_ = obstacles;
-  robot_model_ = robot_model;
   via_points_ = via_points;
   cost_ = HUGE_VAL;
   prefer_rotdir_ = RotType::none;
@@ -123,7 +117,7 @@ void TebOptimalPlanner::visualize()
   visualization_->publishLocalPlanAndPoses(teb_);
   
   if (teb_.sizePoses() > 0)
-    visualization_->publishRobotFootprintModel(teb_.Pose(0), *robot_model_);
+    visualization_->publishRobotFootprintModel(teb_.Pose(0), *cfg_->robot_model);
   
   if (cfg_->trajectory.publish_feedback)
     visualization_->publishFeedbackMessage(*this, *obstacles_);
@@ -469,7 +463,7 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
       EdgeInflatedObstacle* dist_bandpt_obst = new EdgeInflatedObstacle;
       dist_bandpt_obst->setVertex(0,teb_.PoseVertex(index));
       dist_bandpt_obst->setInformation(information_inflated);
-      dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), obstacle);
+      dist_bandpt_obst->setParameters(*cfg_, obstacle);
       optimizer_->addEdge(dist_bandpt_obst);
     }
     else
@@ -477,7 +471,7 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
       EdgeObstacle* dist_bandpt_obst = new EdgeObstacle;
       dist_bandpt_obst->setVertex(0,teb_.PoseVertex(index));
       dist_bandpt_obst->setInformation(information);
-      dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), obstacle);
+      dist_bandpt_obst->setParameters(*cfg_, obstacle);
       optimizer_->addEdge(dist_bandpt_obst);
     };
   };
@@ -501,7 +495,7 @@ void TebOptimalPlanner::AddEdgesObstacles(double weight_multiplier)
           continue;
 
           // calculate distance to robot model
-          double dist = robot_model_->calculateDistance(teb_.Pose(i), obst.get());
+          double dist = cfg_->robot_model->calculateDistance(teb_.Pose(i), obst.get());
           
           // force considering obstacle if really close to the current pose
         if (dist < cfg_->obstacles.min_obstacle_dist*cfg_->obstacles.obstacle_association_force_inclusion_factor)
@@ -589,7 +583,7 @@ void TebOptimalPlanner::AddEdgesObstaclesLegacy(double weight_multiplier)
         EdgeInflatedObstacle* dist_bandpt_obst = new EdgeInflatedObstacle;
         dist_bandpt_obst->setVertex(0,teb_.PoseVertex(index));
         dist_bandpt_obst->setInformation(information_inflated);
-        dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), obst->get());
+        dist_bandpt_obst->setParameters(*cfg_, obst->get());
         optimizer_->addEdge(dist_bandpt_obst);
     }
     else
@@ -597,7 +591,7 @@ void TebOptimalPlanner::AddEdgesObstaclesLegacy(double weight_multiplier)
         EdgeObstacle* dist_bandpt_obst = new EdgeObstacle;
         dist_bandpt_obst->setVertex(0,teb_.PoseVertex(index));
         dist_bandpt_obst->setInformation(information);
-        dist_bandpt_obst->setParameters(*cfg_, robot_model_.get(), obst->get());
+        dist_bandpt_obst->setParameters(*cfg_, obst->get());
         optimizer_->addEdge(dist_bandpt_obst);
     }
 
@@ -610,7 +604,7 @@ void TebOptimalPlanner::AddEdgesObstaclesLegacy(double weight_multiplier)
                 EdgeInflatedObstacle* dist_bandpt_obst_n_r = new EdgeInflatedObstacle;
                 dist_bandpt_obst_n_r->setVertex(0,teb_.PoseVertex(index+neighbourIdx));
                 dist_bandpt_obst_n_r->setInformation(information_inflated);
-                dist_bandpt_obst_n_r->setParameters(*cfg_, robot_model_.get(), obst->get());
+                dist_bandpt_obst_n_r->setParameters(*cfg_, obst->get());
                 optimizer_->addEdge(dist_bandpt_obst_n_r);
             }
             else
@@ -618,7 +612,7 @@ void TebOptimalPlanner::AddEdgesObstaclesLegacy(double weight_multiplier)
                 EdgeObstacle* dist_bandpt_obst_n_r = new EdgeObstacle;
                 dist_bandpt_obst_n_r->setVertex(0,teb_.PoseVertex(index+neighbourIdx));
                 dist_bandpt_obst_n_r->setInformation(information);
-                dist_bandpt_obst_n_r->setParameters(*cfg_, robot_model_.get(), obst->get());
+                dist_bandpt_obst_n_r->setParameters(*cfg_, obst->get());
                 optimizer_->addEdge(dist_bandpt_obst_n_r);
             }
       }
@@ -629,7 +623,7 @@ void TebOptimalPlanner::AddEdgesObstaclesLegacy(double weight_multiplier)
                 EdgeInflatedObstacle* dist_bandpt_obst_n_l = new EdgeInflatedObstacle;
                 dist_bandpt_obst_n_l->setVertex(0,teb_.PoseVertex(index-neighbourIdx));
                 dist_bandpt_obst_n_l->setInformation(information_inflated);
-                dist_bandpt_obst_n_l->setParameters(*cfg_, robot_model_.get(), obst->get());
+                dist_bandpt_obst_n_l->setParameters(*cfg_, obst->get());
                 optimizer_->addEdge(dist_bandpt_obst_n_l);
             }
             else
@@ -637,7 +631,7 @@ void TebOptimalPlanner::AddEdgesObstaclesLegacy(double weight_multiplier)
                 EdgeObstacle* dist_bandpt_obst_n_l = new EdgeObstacle;
                 dist_bandpt_obst_n_l->setVertex(0,teb_.PoseVertex(index-neighbourIdx));
                 dist_bandpt_obst_n_l->setInformation(information);
-                dist_bandpt_obst_n_l->setParameters(*cfg_, robot_model_.get(), obst->get());
+                dist_bandpt_obst_n_l->setParameters(*cfg_, obst->get());
                 optimizer_->addEdge(dist_bandpt_obst_n_l);
             }
       }
@@ -669,7 +663,7 @@ void TebOptimalPlanner::AddEdgesDynamicObstacles(double weight_multiplier)
       EdgeDynamicObstacle* dynobst_edge = new EdgeDynamicObstacle(time);
       dynobst_edge->setVertex(0,teb_.PoseVertex(i));
       dynobst_edge->setInformation(information);
-      dynobst_edge->setParameters(*cfg_, robot_model_.get(), obst->get());
+      dynobst_edge->setParameters(*cfg_, obst->get());
       optimizer_->addEdge(dynobst_edge);
       time += teb_.TimeDiff(i); // we do not need to check the time diff bounds, since we iterate to "< sizePoses()-1".
     }
@@ -1018,7 +1012,7 @@ void TebOptimalPlanner::AddEdgesVelocityObstacleRatio()
       edge->setVertex(1,teb_.PoseVertex(index + 1));
       edge->setVertex(2,teb_.TimeDiffVertex(index));
       edge->setInformation(information);
-      edge->setParameters(*cfg_, robot_model_.get(), obstacle.get());
+      edge->setParameters(*cfg_, obstacle.get());
       optimizer_->addEdge(edge);
     }
   }
@@ -1245,7 +1239,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
     {
       if (visualization_)
       {
-        visualization_->publishInfeasibleRobotPose(teb().Pose(i), *robot_model_);
+        visualization_->publishInfeasibleRobotPose(teb().Pose(i), *cfg_->robot_model);
       }
       return false;
     }
@@ -1272,7 +1266,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
           {
             if (visualization_) 
             {
-              visualization_->publishInfeasibleRobotPose(intermediate_pose, *robot_model_);
+              visualization_->publishInfeasibleRobotPose(intermediate_pose, *cfg_->robot_model);
             }
             return false;
           }

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -82,6 +82,9 @@ void TebLocalPlannerROS::reconfigureCB(TebLocalPlannerReconfigureConfig& config,
 {
   cfg_.reconfigure(config);
   ros::NodeHandle nh("~/" + name_);
+  // lock the config mutex externally
+  boost::mutex::scoped_lock lock(cfg_.configMutex());
+
   // create robot footprint/contour model for optimization
   cfg_.robot_model = getRobotFootprintFromParamServer(nh);
 }

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -83,8 +83,7 @@ void TebLocalPlannerROS::reconfigureCB(TebLocalPlannerReconfigureConfig& config,
   cfg_.reconfigure(config);
   ros::NodeHandle nh("~/" + name_);
   // create robot footprint/contour model for optimization
-  RobotFootprintModelPtr robot_model = getRobotFootprintFromParamServer(nh);
-  planner_->updateRobotModel(robot_model);
+  cfg_.robot_model = getRobotFootprintFromParamServer(nh);
 }
 
 void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costmap_2d::Costmap2DROS* costmap_ros)
@@ -106,17 +105,17 @@ void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costm
     visualization_ = TebVisualizationPtr(new TebVisualization(nh, cfg_)); 
         
     // create robot footprint/contour model for optimization
-    RobotFootprintModelPtr robot_model = getRobotFootprintFromParamServer(nh);
+    cfg_.robot_model = getRobotFootprintFromParamServer(nh);
     
     // create the planner instance
     if (cfg_.hcp.enable_homotopy_class_planning)
     {
-      planner_ = PlannerInterfacePtr(new HomotopyClassPlanner(cfg_, &obstacles_, robot_model, visualization_, &via_points_));
+      planner_ = PlannerInterfacePtr(new HomotopyClassPlanner(cfg_, &obstacles_, visualization_, &via_points_));
       ROS_INFO("Parallel planning in distinctive topologies enabled.");
     }
     else
     {
-      planner_ = PlannerInterfacePtr(new TebOptimalPlanner(cfg_, &obstacles_, robot_model, visualization_, &via_points_));
+      planner_ = PlannerInterfacePtr(new TebOptimalPlanner(cfg_, &obstacles_, visualization_, &via_points_));
       ROS_INFO("Parallel planning in distinctive topologies disabled.");
     }
     
@@ -170,7 +169,7 @@ void TebLocalPlannerROS::initialize(std::string name, tf2_ros::Buffer* tf, costm
     dynamic_recfg_->setCallback(cb);
     
     // validate optimization footprint and costmap footprint
-    validateFootprints(robot_model->getInscribedRadius(), robot_inscribed_radius_, cfg_.obstacles.min_obstacle_dist);
+    validateFootprints(cfg_.robot_model->getInscribedRadius(), robot_inscribed_radius_, cfg_.obstacles.min_obstacle_dist);
         
     // setup callback for custom obstacles
     custom_obst_sub_ = nh.subscribe("obstacles", 1, &TebLocalPlannerROS::customObstacleCB, this);

--- a/src/test_optim_node.cpp
+++ b/src/test_optim_node.cpp
@@ -147,13 +147,13 @@ int main( int argc, char** argv )
   visual = TebVisualizationPtr(new TebVisualization(n, config));
   
   // Setup robot shape model
-  RobotFootprintModelPtr robot_model = TebLocalPlannerROS::getRobotFootprintFromParamServer(n);
+  config.robot_model = TebLocalPlannerROS::getRobotFootprintFromParamServer(n);
   
   // Setup planner (homotopy class planning or just the local teb planner)
   if (config.hcp.enable_homotopy_class_planning)
-    planner = PlannerInterfacePtr(new HomotopyClassPlanner(config, &obst_vector, robot_model, visual, &via_points));
+    planner = PlannerInterfacePtr(new HomotopyClassPlanner(config, &obst_vector, visual, &via_points));
   else
-    planner = PlannerInterfacePtr(new TebOptimalPlanner(config, &obst_vector, robot_model, visual, &via_points));
+    planner = PlannerInterfacePtr(new TebOptimalPlanner(config, &obst_vector, visual, &via_points));
   
 
   no_fixed_obstacles = obst_vector.size();


### PR DESCRIPTION
PR fixes issue #245 

The fix moves the ownership of the footprint from the optimizers to the teb_config class. While this change is debatable (keeping stuff separate is cool) it allows a straight forward fix of the tagged issue and makes dedicated interfaces for setting the footprint obsolete. It might also be acceptable to view the footprint as part of the config for a robot controller (but as said, also fine not to do so).

The positive side effects of this fix are
* the footprint is then constant for the optimal_planner and homotopy_class_planner
* the "default footprint" (PointRobotFootprint) is defined only once.
* one could make the footprint unique_ptr instead of shared, making the ownership clearer