### PR TITLE
[feature] Divergence detection

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -400,5 +400,25 @@ grp_recovery.add("shrink_horizon_backup",   bool_t,   0,
 grp_recovery.add("oscillation_recovery",   bool_t,   0,
   "Try to detect and resolve oscillations between multiple solutions in the same equivalence class (robot frequently switches between left/right/forward/backwards).",
   True) 
-  
+
+grp_recovery_divergence = grp_recovery.add_group("Divergence Detection", type="hide")
+
+grp_recovery_divergence.add(
+    "divergence_detection_enable",
+    bool_t,
+    0,
+    "True to enable divergence detection.",
+    False
+)
+
+grp_recovery_divergence.add(
+    "divergence_detection_max_chi_squared",
+    double_t,
+    0,
+    "Maximum acceptable Mahalanobis distance above which it is assumed that the optimization diverged.",
+    10,
+    0,
+    100
+)
+
 exit(gen.generate("teb_local_planner", "teb_local_planner", "TebLocalPlannerReconfigure"))

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -394,6 +394,8 @@ public:
    */
   const TebOptPlannerContainer& getTrajectoryContainer() const {return tebs_;}
 
+  bool hasDiverged() const override {return false;}
+
   /**
    * Compute and return the cost of the current optimization graph (supports multiple trajectories)
    * @param[out] cost current cost value for each trajectory

--- a/include/teb_local_planner/homotopy_class_planner.h
+++ b/include/teb_local_planner/homotopy_class_planner.h
@@ -394,7 +394,7 @@ public:
    */
   const TebOptPlannerContainer& getTrajectoryContainer() const {return tebs_;}
 
-  bool hasDiverged() const override {return false;}
+  bool hasDiverged() const override;
 
   /**
    * Compute and return the cost of the current optimization graph (supports multiple trajectories)

--- a/include/teb_local_planner/optimal_planner.h
+++ b/include/teb_local_planner/optimal_planner.h
@@ -391,6 +391,11 @@ public:
    *         otherwise \c false (also if no optimization has been called before).
    */
   bool isOptimized() const {return optimized_;};
+
+  /**
+   * @brief Returns true if the planner has diverged.
+   */
+  bool hasDiverged() const override;
 	
   /**
    * @brief Compute the cost vector of a given optimization problen (hyper-graph must exist).

--- a/include/teb_local_planner/planner_interface.h
+++ b/include/teb_local_planner/planner_interface.h
@@ -190,7 +190,12 @@ public:
    */
   virtual void computeCurrentCost(std::vector<double>& cost, double obst_cost_scale=1.0, bool alternative_time_cost=false)
   {
-  }      
+  }
+
+  /**
+   * @brief Returns true if the planner has diverged.
+   */
+  virtual bool hasDiverged() const = 0;
                 
 };
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -216,6 +216,8 @@ public:
     double oscillation_omega_eps; //!< Threshold for the average normalized angular velocity: if oscillation_v_eps and oscillation_omega_eps are not exceeded both, a possible oscillation is detected
     double oscillation_recovery_min_duration; //!< Minumum duration [sec] for which the recovery mode is activated after an oscillation is detected.
     double oscillation_filter_duration; //!< Filter length/duration [sec] for the detection of oscillations
+    bool divergence_detection_enable; //!< True to enable divergence detection.
+    int divergence_detection_max_chi_squared; //!< Maximum acceptable Mahalanobis distance above which it is assumed that the optimization diverged.
   } recovery; //!< Parameters related to recovery and backup strategies
 
 

--- a/src/homotopy_class_planner.cpp
+++ b/src/homotopy_class_planner.cpp
@@ -748,6 +748,15 @@ void HomotopyClassPlanner::setPreferredTurningDir(RotType dir)
   }
 }
 
+bool HomotopyClassPlanner::hasDiverged() const
+{
+  // Early return if there is no best trajectory initialized
+  if (!best_teb_)
+    return false;
+
+  return best_teb_->hasDiverged();
+}
+
 void HomotopyClassPlanner::computeCurrentCost(std::vector<double>& cost, double obst_cost_scale, double viapoint_cost_scale, bool alternative_time_cost)
 {
   for (TebOptPlannerContainer::iterator it_teb = tebs_.begin(); it_teb != tebs_.end(); ++it_teb)

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -333,6 +333,8 @@ bool TebOptimalPlanner::buildGraph(double weight_multiplier)
     ROS_WARN("Cannot build graph, because it is not empty. Call graphClear()!");
     return false;
   }
+
+  optimizer_->setComputeBatchStatistics(cfg_->recovery.divergence_detection_enable);
   
   // add TEB vertices
   AddTEBVertices();
@@ -1022,6 +1024,24 @@ void TebOptimalPlanner::AddEdgesVelocityObstacleRatio()
       optimizer_->addEdge(edge);
     }
   }
+}
+
+bool TebOptimalPlanner::hasDiverged() const
+{
+  // Early returns if divergence detection is not active
+  if (!cfg_->recovery.divergence_detection_enable)
+    return false;
+
+  auto stats_vector = optimizer_->batchStatistics();
+
+  // No statistics yet
+  if (stats_vector.empty())
+    return false;
+
+  // Grab the statistics of the final iteration
+  const auto last_iter_stats = stats_vector.back();
+
+  return last_iter_stats.chi2 > cfg_->recovery.divergence_detection_max_chi_squared;
 }
 
 void TebOptimalPlanner::computeCurrentCost(double obst_cost_scale, double viapoint_cost_scale, bool alternative_time_cost)

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -170,6 +170,8 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("oscillation_omega_eps", recovery.oscillation_omega_eps, recovery.oscillation_omega_eps);
   nh.param("oscillation_recovery_min_duration", recovery.oscillation_recovery_min_duration, recovery.oscillation_recovery_min_duration);
   nh.param("oscillation_filter_duration", recovery.oscillation_filter_duration, recovery.oscillation_filter_duration);
+  nh.param("divergence_detection", recovery.divergence_detection_enable, recovery.divergence_detection_enable);
+  nh.param("divergence_detection_max_chi_squared", recovery.divergence_detection_max_chi_squared, recovery.divergence_detection_max_chi_squared);
 
   checkParameters();
   checkDeprecated(nh);
@@ -276,9 +278,11 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   hcp.visualize_with_time_as_z_axis_scale = cfg.visualize_with_time_as_z_axis_scale;
   
   // Recovery
-  
   recovery.shrink_horizon_backup = cfg.shrink_horizon_backup;
   recovery.oscillation_recovery = cfg.oscillation_recovery;
+  recovery.divergence_detection_enable = cfg.divergence_detection_enable;
+  recovery.divergence_detection_max_chi_squared = cfg.divergence_detection_max_chi_squared;
+
   
   checkParameters();
 }


### PR DESCRIPTION
### Why
This is an edge case in my application, but if an obstacle suddenly appears in front of the robot, TEB's solution might diverge quite noticeably. As an example, I obtained the image below by suddenly dropping an obstacle in front of the robot in simulation.

![image](https://user-images.githubusercontent.com/5129986/101485069-e662b300-395a-11eb-94f9-7175215bd66b.png)

### Summary
After some investigation, I've observed that (given my configuration) the value of `chi2` in the optimizer statistics remains around 1 when the robot is navigating. Still, it increases drastically if the trajectory diverges, reaching values above 1000. This seemed to me to be the best parameter to monitor to detect divergence, but I might be missing the context of other applications (my robot is a differential drive one, which runs at most at 0.75 m/s).

### Related Issues
Might help with #61 #257 #7 #200 