### PR TITLE
Fixed pruning when rotation in place

### DIFF
--- a/include/teb_local_planner/timed_elastic_band.h
+++ b/include/teb_local_planner/timed_elastic_band.h
@@ -642,6 +642,8 @@ public:
   //@}
 	
 protected:
+  int findNearestStartState(const PoseSE2& new_start, int min_samples, std::function<double(const PoseSE2&, const PoseSE2&)> distance);
+
   PoseSequence pose_vec_; //!< Internal container storing the sequence of optimzable pose vertices
   TimeDiffSequence timediff_vec_;  //!< Internal container storing the sequence of optimzable timediff vertices
   


### PR DESCRIPTION
Currently the pruning of the TEB only considers the position when looking for the closest pose. This creates a problem in case the TEB contains several poses in the same position but with different orientation (i.e., robot rotating on the spot). This PR fixes this problem by checking the orientation in case the closest position is the first one.