### PR TITLE
Wait for robot to stop before setting goal reached

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -155,12 +155,13 @@ grp_goal.add("free_goal_vel",   bool_t,   0,
 	False)
 
 grp_goal.add("trans_stopped_vel",   double_t,   0,
-       "Below what maximum velocity we consider the robot to be stopped in translation",
-       0.1, 0.01, 100)
+	"Below what maximum velocity we consider the robot to be stopped in translation",
+	0.1, 0.0)
 
 grp_goal.add("theta_stopped_vel",   double_t,   0,
-       "Below what maximum rotation velocity we consider the robot to be stopped in rotation",
-       0.1, 0.01, 100)
+	"Below what maximum rotation velocity we consider the robot to be stopped in rotation",
+	0.1, 0.0)
+
 # Obstacles
 grp_obstacles = gen.add_group("Obstacles", type="tab")
 

--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -153,7 +153,14 @@ grp_goal.add("yaw_goal_tolerance", double_t, 0,
 grp_goal.add("free_goal_vel",   bool_t,   0, 
 	"Allow the robot's velocity to be nonzero for planning purposes (the robot can arrive at the goal with max speed)", 
 	False)
-    
+
+grp_goal.add("trans_stopped_vel",   double_t,   0,
+       "Below what maximum velocity we consider the robot to be stopped in translation",
+       0.1, 0.01, 100)
+
+grp_goal.add("theta_stopped_vel",   double_t,   0,
+       "Below what maximum rotation velocity we consider the robot to be stopped in rotation",
+       0.1, 0.01, 100)
 # Obstacles
 grp_obstacles = gen.add_group("Obstacles", type="tab")
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -112,6 +112,8 @@ public:
     double yaw_goal_tolerance; //!< Allowed final orientation error
     double xy_goal_tolerance; //!< Allowed final euclidean distance to the goal position
     bool free_goal_vel; //!< Allow the robot's velocity to be nonzero (usally max_vel) for planning purposes
+    double trans_stopped_vel; //!< Below what maximum velocity we consider the robot to be stopped in translation
+    double theta_stopped_vel; //!< Below what maximum rotation velocity we consider the robot to be stopped in rotation
     bool complete_global_plan; // true prevents the robot from ending the path early when it cross the end goal
   } goal_tolerance; //!< Goal tolerance related parameters
 
@@ -281,6 +283,8 @@ public:
     goal_tolerance.xy_goal_tolerance = 0.2;
     goal_tolerance.yaw_goal_tolerance = 0.2;
     goal_tolerance.free_goal_vel = false;
+    goal_tolerance.trans_stopped_vel = 0.1;
+    goal_tolerance.theta_stopped_vel = 0.1;
     goal_tolerance.complete_global_plan = true;
 
     // Obstacles

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -88,6 +88,8 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("xy_goal_tolerance", goal_tolerance.xy_goal_tolerance, goal_tolerance.xy_goal_tolerance);
   nh.param("yaw_goal_tolerance", goal_tolerance.yaw_goal_tolerance, goal_tolerance.yaw_goal_tolerance);
   nh.param("free_goal_vel", goal_tolerance.free_goal_vel, goal_tolerance.free_goal_vel);
+  nh.param("trans_stopped_vel", goal_tolerance.trans_stopped_vel, goal_tolerance.trans_stopped_vel);
+  nh.param("theta_stopped_vel", goal_tolerance.theta_stopped_vel, goal_tolerance.theta_stopped_vel);
   nh.param("complete_global_plan", goal_tolerance.complete_global_plan, goal_tolerance.complete_global_plan);
 
   // Obstacles
@@ -213,7 +215,9 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   goal_tolerance.xy_goal_tolerance = cfg.xy_goal_tolerance;
   goal_tolerance.yaw_goal_tolerance = cfg.yaw_goal_tolerance;
   goal_tolerance.free_goal_vel = cfg.free_goal_vel;
-  
+  goal_tolerance.trans_stopped_vel = cfg.trans_stopped_vel;
+  goal_tolerance.theta_stopped_vel = cfg.theta_stopped_vel;
+
   // Obstacles
   obstacles.min_obstacle_dist = cfg.min_obstacle_dist;
   obstacles.inflation_dist = cfg.inflation_dist;

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -293,7 +293,8 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   if(fabs(std::sqrt(dx*dx+dy*dy)) < cfg_.goal_tolerance.xy_goal_tolerance
     && fabs(delta_orient) < cfg_.goal_tolerance.yaw_goal_tolerance
     && (!cfg_.goal_tolerance.complete_global_plan || via_points_.size() == 0)
-     && (!cfg_.goal_tolerance.free_goal_vel && base_local_planner::stopped(base_odom, cfg_.goal_tolerance.theta_stopped_vel, cfg_.goal_tolerance.trans_stopped_vel) || cfg_.goal_tolerance.free_goal_vel))
+    && (base_local_planner::stopped(base_odom, cfg_.goal_tolerance.theta_stopped_vel, cfg_.goal_tolerance.trans_stopped_vel)
+        || cfg_.goal_tolerance.free_goal_vel))
   {
     goal_reached_ = true;
     return mbf_msgs::ExePathResult::SUCCESS;

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -281,6 +281,9 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   if (!custom_via_points_active_)
     updateViaPointsContainer(transformed_plan, cfg_.trajectory.global_plan_viapoint_sep);
 
+  nav_msgs::Odometry base_odom;
+  odom_helper_.getOdom(base_odom);
+
   // check if global goal is reached
   geometry_msgs::PoseStamped global_goal;
   tf2::doTransform(global_plan_.back(), global_goal, tf_plan_to_global);
@@ -289,13 +292,13 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   double delta_orient = g2o::normalize_theta( tf2::getYaw(global_goal.pose.orientation) - robot_pose_.theta() );
   if(fabs(std::sqrt(dx*dx+dy*dy)) < cfg_.goal_tolerance.xy_goal_tolerance
     && fabs(delta_orient) < cfg_.goal_tolerance.yaw_goal_tolerance
-    && (!cfg_.goal_tolerance.complete_global_plan || via_points_.size() == 0))
+    && (!cfg_.goal_tolerance.complete_global_plan || via_points_.size() == 0)
+     && (!cfg_.goal_tolerance.free_goal_vel && base_local_planner::stopped(base_odom, cfg_.goal_tolerance.theta_stopped_vel, cfg_.goal_tolerance.trans_stopped_vel) || cfg_.goal_tolerance.free_goal_vel))
   {
     goal_reached_ = true;
     return mbf_msgs::ExePathResult::SUCCESS;
   }
-  
-  
+
   // check if we should enter any backup mode and apply settings
   configureBackupModes(transformed_plan, goal_idx);
   


### PR DESCRIPTION
### Feature addition ###
Planners like [dwa_local_planner](http://wiki.ros.org/dwa_local_planner) and [base_local_planner](http://wiki.ros.org/base_local_planner) uses [base_local_planner::LocalPlannerLimits](http://docs.ros.org/en/api/base_local_planner/html/classbase__local__planner_1_1LocalPlannerLimits.html) class and enables users to set stop velocities. This is used to make sure that the robot has actually stopped before returning success. This avoids issues of overshooting the goal after the planner has returned success.

#### Changes ####
In this PR two new parameters are introduced, `trans_stopped_vel` and `theta_stopped_vel` that ensures the robot achieves translational and rotational velocity below specified thresholds, respectively, before returning success.

#### Testing ####
Tested by manually publishing mock data to the odom topic.