### PR TITLE
[ros2-mater] xy_goal_tolerance from GoalChecker + remove xy_goal_tolerance param

### DIFF
--- a/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
+++ b/teb_local_planner/cfg/TebLocalPlannerReconfigure.cfg
@@ -145,10 +145,6 @@ grp_robot_omni.add("acc_lim_y", double_t, 0,
 
 # GoalTolerance
 grp_goal = gen.add_group("GoalTolerance", type="tab")
-
-grp_goal.add("xy_goal_tolerance", double_t, 0,
-	"Allowed final euclidean distance to the goal position",
-	0.2, 0.001, 10) 
     
 grp_goal.add("free_goal_vel",   bool_t,   0, 
 	"Allow the robot's velocity to be nonzero for planning purposes (the robot can arrive at the goal with max speed)", 

--- a/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
+++ b/teb_local_planner/include/teb_local_planner/teb_local_planner_ros.h
@@ -135,7 +135,8 @@ public:
     */
   geometry_msgs::msg::TwistStamped computeVelocityCommands(
     const geometry_msgs::msg::PoseStamped &pose,
-    const geometry_msgs::msg::Twist &velocity);
+    const geometry_msgs::msg::Twist &velocity,
+      nav2_core::GoalChecker * goal_checker);
   
     
   /** @name Public utility functions/methods */

--- a/teb_local_planner/params/teb_params.yaml
+++ b/teb_local_planner/params/teb_params.yaml
@@ -34,7 +34,6 @@ controller_server:
 
       # GoalTolerance
               
-      xy_goal_tolerance: 0.2
       free_goal_vel: False
           
       # Obstacles

--- a/teb_local_planner/src/teb_config.cpp
+++ b/teb_local_planner/src/teb_config.cpp
@@ -80,7 +80,6 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
   nh->declare_parameter(name + "." + "is_footprint_dynamic", rclcpp::ParameterValue(robot.is_footprint_dynamic));
   
   // GoalTolerance
-  nh->declare_parameter(name + "." + "xy_goal_tolerance", rclcpp::ParameterValue(goal_tolerance.xy_goal_tolerance));
   nh->declare_parameter(name + "." + "free_goal_vel", rclcpp::ParameterValue(goal_tolerance.free_goal_vel));
 
   // Obstacles
@@ -206,7 +205,6 @@ void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::Share
   nh->get_parameter_or(name + "." + "is_footprint_dynamic", robot.is_footprint_dynamic, robot.is_footprint_dynamic);
   
   // GoalTolerance
-  nh->get_parameter_or(name + "." + "xy_goal_tolerance", goal_tolerance.xy_goal_tolerance, goal_tolerance.xy_goal_tolerance);
   nh->get_parameter_or(name + "." + "free_goal_vel", goal_tolerance.free_goal_vel, goal_tolerance.free_goal_vel);
 
   // Obstacles
@@ -327,7 +325,6 @@ void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::Share
 //  robot.cmd_angle_instead_rotvel = cfg.cmd_angle_instead_rotvel;
   
 //  // GoalTolerance
-//  goal_tolerance.xy_goal_tolerance = cfg.xy_goal_tolerance;
 //  goal_tolerance.free_goal_vel = cfg.free_goal_vel;
   
 //  // Obstacles

--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -253,9 +253,8 @@ void TebLocalPlannerROS::setPlan(const nav_msgs::msg::Path & orig_global_plan)
 }
 
 
-geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
-  const geometry_msgs::msg::PoseStamped &pose,
-  const geometry_msgs::msg::Twist &velocity)
+geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::msg::PoseStamped &pose,
+  const geometry_msgs::msg::Twist &velocity, nav2_core::GoalChecker *goal_checker)
 {
   // check if plugin initialized
   if(!initialized_)
@@ -271,6 +270,15 @@ geometry_msgs::msg::TwistStamped TebLocalPlannerROS::computeVelocityCommands(
   cmd_vel.twist.linear.x = 0;
   cmd_vel.twist.linear.y = 0;
   cmd_vel.twist.angular.z = 0;
+
+  // Update for the current goal checker's state
+  geometry_msgs::msg::Pose pose_tolerance;
+  geometry_msgs::msg::Twist vel_tolerance;
+  if (!goal_checker->getTolerances(pose_tolerance, vel_tolerance)) {
+    RCLCPP_WARN(logger_, "Unable to retrieve goal checker's tolerances!");
+  } else {
+    cfg_->goal_tolerance.xy_goal_tolerance = pose_tolerance.position.x;
+  }
   
   // Get robot pose
   robot_pose_ = PoseSE2(pose.pose);


### PR DESCRIPTION
Last nav2 main changes the `computeVelocityCommands` interface. This PR fix compilation against last nav2 main and use the newly added goal_checker arg to retrieve the `xy_goal_tolerance` from the goal_checker arg as discussed here: https://github.com/rst-tu-dortmund/teb_local_planner/pull/284#issuecomment-800483825
Plus remove unneeded `xy_goal_tolerance` TEB param (goal tolerances should be set with the GoalChecker plugin params from now)