### PR TITLE
Fixed a bug on isGoalReached method

### DIFF
--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -426,7 +426,6 @@ private:
   PoseSE2 robot_pose_; //!< Store current robot pose
   PoseSE2 robot_goal_; //!< Store current robot goal
   geometry_msgs::Twist robot_vel_; //!< Store current robot translational and angular velocity (vx, vy, omega)
-  // bool goal_reached_; //!< store whether the goal is reached or not
   ros::Time time_last_infeasible_plan_; //!< Store at which time stamp the last infeasible plan was detected
   int no_infeasible_plans_; //!< Store how many times in a row the planner failed to find a feasible plan.
   ros::Time time_last_oscillation_; //!< Store at which time stamp the last oscillation was detected
@@ -443,8 +442,6 @@ private:
     
   // flags
   bool initialized_; //!< Keeps track about the correct initialization of this class
-
-  geometry_msgs::PoseStamped global_goal;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -426,7 +426,7 @@ private:
   PoseSE2 robot_pose_; //!< Store current robot pose
   PoseSE2 robot_goal_; //!< Store current robot goal
   geometry_msgs::Twist robot_vel_; //!< Store current robot translational and angular velocity (vx, vy, omega)
-  bool goal_reached_; //!< store whether the goal is reached or not
+  // bool goal_reached_; //!< store whether the goal is reached or not
   ros::Time time_last_infeasible_plan_; //!< Store at which time stamp the last infeasible plan was detected
   int no_infeasible_plans_; //!< Store how many times in a row the planner failed to find a feasible plan.
   ros::Time time_last_oscillation_; //!< Store at which time stamp the last oscillation was detected
@@ -443,6 +443,8 @@ private:
     
   // flags
   bool initialized_; //!< Keeps track about the correct initialization of this class
+
+  geometry_msgs::PoseStamped global_goal;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -278,11 +278,6 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   if (!custom_via_points_active_)
     updateViaPointsContainer(transformed_plan, cfg_.trajectory.global_plan_viapoint_sep);
 
-  // check if global goal is reached
-  if(isGoalReached()) {
-    return mbf_msgs::ExePathResult::SUCCESS;
-  }
-
   // check if we should enter any backup mode and apply settings
   configureBackupModes(transformed_plan, goal_idx);
   
@@ -443,7 +438,7 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
 
 bool TebLocalPlannerROS::isGoalReached()
 {
-  if(!initialized_ || global_plan_.empty()) /* check if the planner was initialized and it there is a global plan */
+  if(!initialized_ || ! global_plan_.size() > 0) /* check if the planner was initialized and it there is a global plan */
   {
     return false;
   }
@@ -474,6 +469,7 @@ bool TebLocalPlannerROS::isGoalReached()
       && (base_local_planner::stopped(base_odom, cfg_.goal_tolerance.theta_stopped_vel, cfg_.goal_tolerance.trans_stopped_vel)
           || cfg_.goal_tolerance.free_goal_vel))
     {
+      planner_->clearPlanner();
       return true;
     }
   }


### PR DESCRIPTION
There was a bug on `goal_reached_` flag where the robot wouldn't realize that a goal is reached. It was caused by a new global plan arriving before the `move_base` check if the goal is reached. 

**How the bug happens**: The `computeVelocityCommands` method set the flag to true, then a new plan arrives and the `setPlan` method is called. Then, on the `setPlan`, the flag is set back to false before it was actually checked. So when the `isGoalReached` method is called, it keeps returning false.

**Proposed Solution**: The solution proposed here is to check the goal using the global plan, so it doesn't depend on the `goal_reached_` flag anymore and even with a new plan be capable to realize that the goal is reached.