### PR TITLE
[ros2-master] fix prune path

### DIFF
--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -661,8 +661,8 @@ bool TebLocalPlannerROS::pruneGlobalPlan(const geometry_msgs::msg::PoseStamped& 
     // transform robot pose into the plan frame (we do not wait here, since pruning not crucial, if missed a few times)
     //geometry_msgs::msg::TransformStamped global_to_plan_transform = tf_->lookupTransform(global_plan.front().header.frame_id, global_pose.header.frame_id, tf2::timeFromSec(0));
     geometry_msgs::msg::PoseStamped robot = tf_->transform(
-                global_plan.front(),
-                global_pose.header.frame_id);
+              global_pose,
+              global_plan.front().header.frame_id);
 
     //robot.setData( global_to_plan_transform * global_pose );
     


### PR DESCRIPTION
Similar to https://github.com/rst-tu-dortmund/teb_local_planner/pull/198 but against last version of the [ros2-master] branch.
Fix https://github.com/rst-tu-dortmund/teb_local_planner/issues/203
I was able to reproduce the issue and check that it is fixed with this PR:
Before PR:
![teb_prune2](https://user-images.githubusercontent.com/15727892/112145901-38aea380-8bdb-11eb-8cea-52bf0f0144ba.gif)
