### PR TITLE
robot footprint model access specifiers loosened

### DIFF
--- a/include/teb_local_planner/robot_footprint_model.h
+++ b/include/teb_local_planner/robot_footprint_model.h
@@ -107,7 +107,7 @@ public:
    * @brief Compute the inscribed radius of the footprint model
    * @return inscribed radius
    */
-  virtual double getInscribedRadius() = 0;
+  virtual double getInscribedRadius() const = 0;
 
 	
 
@@ -172,7 +172,7 @@ public:
    * @brief Compute the inscribed radius of the footprint model
    * @return inscribed radius
    */
-  virtual double getInscribedRadius() {return 0.0;}
+  virtual double getInscribedRadius() const {return 0.0;}
 
 };
 
@@ -249,7 +249,7 @@ public:
    * @brief Compute the inscribed radius of the footprint model
    * @return inscribed radius
    */
-  virtual double getInscribedRadius() {return radius_;}
+  virtual double getInscribedRadius() const {return radius_;}
 
 private:
     
@@ -362,14 +362,14 @@ public:
    * @brief Compute the inscribed radius of the footprint model
    * @return inscribed radius
    */
-  virtual double getInscribedRadius() 
+  virtual double getInscribedRadius() const
   {
       double min_longitudinal = std::min(rear_offset_ + rear_radius_, front_offset_ + front_radius_);
       double min_lateral = std::min(rear_radius_, front_radius_);
       return std::min(min_longitudinal, min_lateral);
   }
 
-private:
+protected:
     
   double front_offset_;
   double front_radius_;
@@ -501,12 +501,12 @@ public:
    * @brief Compute the inscribed radius of the footprint model
    * @return inscribed radius
    */
-  virtual double getInscribedRadius() 
+  virtual double getInscribedRadius() const
   {
       return 0.0; // lateral distance = 0.0
   }
 
-private:
+protected:
     
   /**
     * @brief Transforms a line to the world frame manually
@@ -631,7 +631,7 @@ public:
    * @brief Compute the inscribed radius of the footprint model
    * @return inscribed radius
    */
-  virtual double getInscribedRadius() 
+  virtual double getInscribedRadius() const
   {
      double min_dist = std::numeric_limits<double>::max();
      Eigen::Vector2d center(0.0, 0.0);
@@ -653,7 +653,7 @@ public:
      return std::min(min_dist, std::min(vertex_dist, edge_dist));
   }
 
-private:
+protected:
     
   /**
     * @brief Transforms a polygon to the world frame manually


### PR DESCRIPTION
I propose minor changes in `robot_footprint_model` to allow more extension possibilities (for e.g. planners which use similar environment representation).

- `BaseRobotFootprint` class
    - `getInscribedRadius` was a non-const method even though none of the members are changed in any of derived classes
- `TwoCirclesRobotFootprint` class
    - `front_offset`, `front_radius`, `rear_offset`, `rear_radius` are marked as private which kinda blocks extension possibilities
- `LineRobotFootprint` class
    - `transformToWorld` method was private, similarly, `line_start` and `line_end`