### PR TITLE
add max vel linear

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -143,8 +143,8 @@ grp_robot_omni.add("max_vel_y", double_t, 0,
   "Maximum strafing velocity of the robot (should be zero for non-holonomic robots!)",
   0.0, 0.0, 100)
 
-grp_robot_omni.add("max_vel_linear", double_t, 0, 
-  "Maximum linear velocity of the robot. Ignore this parameter for non-holonomic robots (max_vel_linear == max_vel_x).",
+grp_robot_omni.add("max_vel_trans", double_t, 0, 
+  "Maximum linear velocity of the robot. Ignore this parameter for non-holonomic robots (max_vel_trans == max_vel_x).",
   0.4, 0.01, 100)
 
 grp_robot_omni.add("acc_lim_y", double_t, 0, 
@@ -334,8 +334,8 @@ grp_optimization.add("obstacle_cost_exponent", double_t, 0,
 # Optimization/Omni
 grp_optimization_omni = grp_optimization.add_group("OptOmni", type="hide")
 
-grp_optimization_omni.add("norm_vel_lin", int_t, 0,
-	"Norm constraint for translational velocity (1: L1, 2: L2). For example, enforcing hypot(vx, xy) <= v_max_lin for L2",
+grp_optimization_omni.add("norm_vel_trans", int_t, 0,
+	"Norm constraint for translational velocity (1: L1, 2: L2). For example, enforcing hypot(vx, xy) <= vel_max_trans for L2",
 	1, 1, 2)
   
   

--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -141,6 +141,10 @@ grp_robot_omni = grp_robot.add_group("Omnidirectional", type="hide")
 
 grp_robot_omni.add("max_vel_y", double_t, 0, 
   "Maximum strafing velocity of the robot (should be zero for non-holonomic robots!)",
+  0.0, 0.0, 100)
+
+grp_robot_omni.add("max_vel_linear", double_t, 0, 
+  "Maximum linear velocity of the robot. Ignore this parameter for non-holonomic robots (max_vel_linear == max_vel_x).",
   0.0, 0.0, 100) 
 
 grp_robot_omni.add("acc_lim_y", double_t, 0, 

--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -145,7 +145,7 @@ grp_robot_omni.add("max_vel_y", double_t, 0,
 
 grp_robot_omni.add("max_vel_linear", double_t, 0, 
   "Maximum linear velocity of the robot. Ignore this parameter for non-holonomic robots (max_vel_linear == max_vel_x).",
-  0.0, 0.0, 100) 
+  0.4, 0.01, 100)
 
 grp_robot_omni.add("acc_lim_y", double_t, 0, 
   "Maximum strafing acceleration of the robot",

--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -330,13 +330,6 @@ grp_optimization.add("weight_adapt_factor", double_t, 0,
 grp_optimization.add("obstacle_cost_exponent", double_t, 0,
 	"Exponent for nonlinear obstacle cost (cost = linear_cost * obstacle_cost_exponent). Set to 1 to disable nonlinear cost (default)",
 	1, 0.01, 100)
-
-# Optimization/Omni
-grp_optimization_omni = grp_optimization.add_group("OptOmni", type="hide")
-
-grp_optimization_omni.add("norm_vel_trans", int_t, 0,
-	"Norm constraint for translational velocity (1: L1, 2: L2). For example, enforcing hypot(vx, xy) <= vel_max_trans for L2",
-	1, 1, 2)
   
   
 # Homotopy Class Planner

--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -331,6 +331,12 @@ grp_optimization.add("obstacle_cost_exponent", double_t, 0,
 	"Exponent for nonlinear obstacle cost (cost = linear_cost * obstacle_cost_exponent). Set to 1 to disable nonlinear cost (default)",
 	1, 0.01, 100)
 
+# Optimization/Omni
+grp_optimization_omni = grp_optimization.add_group("OptOmni", type="hide")
+
+grp_optimization_omni.add("norm_vel_lin", int_t, 0,
+	"Norm constraint for translational velocity (1: L1, 2: L2). For example, enforcing hypot(vx, xy) <= v_max_lin for L2",
+	1, 1, 2)
   
   
 # Homotopy Class Planner

--- a/include/teb_local_planner/g2o_types/edge_velocity.h
+++ b/include/teb_local_planner/g2o_types/edge_velocity.h
@@ -253,16 +253,16 @@ public:
     double omega = g2o::normalize_theta(conf2->theta() - conf1->theta()) / deltaT->estimate();
 
 
-    double max_vel_trans_remaining;
-    if (cfg_->optim.norm_vel_trans == 1) {
-      max_vel_trans_remaining = std::max(0.0, cfg_->robot.max_vel_trans - std::abs(vx));  // L1 norm
-    }
-    else {
-      max_vel_trans_remaining = std::sqrt(std::max(0.0, cfg_->robot.max_vel_trans * cfg_->robot.max_vel_trans - vx * vx)); // L2 norm
-    }
-    double max_vel_y = std::min(max_vel_trans_remaining, cfg_->robot.max_vel_y);
+    double max_vel_trans_remaining_y;
+    double max_vel_trans_remaining_x;
+    max_vel_trans_remaining_y = std::sqrt(std::max(0.0, cfg_->robot.max_vel_trans * cfg_->robot.max_vel_trans - vx * vx)); 
+    max_vel_trans_remaining_x = std::sqrt(std::max(0.0, cfg_->robot.max_vel_trans * cfg_->robot.max_vel_trans - vy * vy)); 
 
-    _error[0] = penaltyBoundToInterval(vx, -cfg_->robot.max_vel_x_backwards, cfg_->robot.max_vel_x, cfg_->optim.penalty_epsilon);
+    double max_vel_y = std::min(max_vel_trans_remaining_y, cfg_->robot.max_vel_y);
+    double max_vel_x = std::min(max_vel_trans_remaining_x, cfg_->robot.max_vel_x);
+    double max_vel_x_backwards = std::min(max_vel_trans_remaining_x, cfg_->robot.max_vel_x_backwards);
+
+    _error[0] = penaltyBoundToInterval(vx, -max_vel_x_backwards, max_vel_x, cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(vy, max_vel_y, 0.0); // we do not apply the penalty epsilon here, since the velocity could be close to zero
     _error[2] = penaltyBoundToInterval(omega, cfg_->robot.max_vel_theta,cfg_->optim.penalty_epsilon);
 

--- a/include/teb_local_planner/g2o_types/edge_velocity.h
+++ b/include/teb_local_planner/g2o_types/edge_velocity.h
@@ -252,16 +252,16 @@ public:
     double vy = r_dy / deltaT->estimate();
     double omega = g2o::normalize_theta(conf2->theta() - conf1->theta()) / deltaT->estimate();
 
-    double max_vel_linear = std::max(std::max(cfg_->robot.max_vel_x, cfg_->robot.max_vel_y), cfg_->robot.max_vel_linear);
+    double max_vel_trans = std::max(std::max(cfg_->robot.max_vel_x, cfg_->robot.max_vel_y), cfg_->robot.max_vel_trans);
 
-    double max_linear_vel_remaining;
-    if (cfg_->optim.norm_vel_lin == 1) {
-      max_linear_vel_remaining = max_vel_linear - std::abs(vx);  // L1 norm
+    double max_vel_trans_remaining;
+    if (cfg_->optim.norm_vel_trans == 1) {
+      max_vel_trans_remaining = max_vel_trans - std::abs(vx);  // L1 norm
     }
     else {
-      max_linear_vel_remaining = std::sqrt(max_vel_linear * max_vel_linear - vx * vx); // L2 norm
+      max_vel_trans_remaining = std::sqrt(max_vel_trans * max_vel_trans - vx * vx); // L2 norm
     }
-    double max_vel_y = std::min(max_linear_vel_remaining, cfg_->robot.max_vel_y);
+    double max_vel_y = std::min(max_vel_trans_remaining, cfg_->robot.max_vel_y);
 
     _error[0] = penaltyBoundToInterval(vx, -cfg_->robot.max_vel_x_backwards, cfg_->robot.max_vel_x, cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(vy, max_vel_y, 0.0); // we do not apply the penalty epsilon here, since the velocity could be close to zero

--- a/include/teb_local_planner/g2o_types/edge_velocity.h
+++ b/include/teb_local_planner/g2o_types/edge_velocity.h
@@ -251,9 +251,14 @@ public:
     double vx = r_dx / deltaT->estimate();
     double vy = r_dy / deltaT->estimate();
     double omega = g2o::normalize_theta(conf2->theta() - conf1->theta()) / deltaT->estimate();
-    
+
+    double max_vel_linear = std::max(std::max(cfg_->robot.max_vel_x, cfg_->robot.max_vel_y), cfg_->robot.max_vel_linear);
+    // double max_linear_vel_left = std::sqrt(max_vel_linear * max_vel_linear - vx * vx); // L2
+    double max_linear_vel_left = max_vel_linear - std::abs(vx); // L1
+    double max_vel_y = std::min(max_linear_vel_left, cfg_->robot.max_vel_y);
+
     _error[0] = penaltyBoundToInterval(vx, -cfg_->robot.max_vel_x_backwards, cfg_->robot.max_vel_x, cfg_->optim.penalty_epsilon);
-    _error[1] = penaltyBoundToInterval(vy, cfg_->robot.max_vel_y, 0.0); // we do not apply the penalty epsilon here, since the velocity could be close to zero
+    _error[1] = penaltyBoundToInterval(vy, max_vel_y, 0.0); // we do not apply the penalty epsilon here, since the velocity could be close to zero
     _error[2] = penaltyBoundToInterval(omega, cfg_->robot.max_vel_theta,cfg_->optim.penalty_epsilon);
 
     ROS_ASSERT_MSG(std::isfinite(_error[0]) && std::isfinite(_error[1]) && std::isfinite(_error[2]),

--- a/include/teb_local_planner/g2o_types/edge_velocity.h
+++ b/include/teb_local_planner/g2o_types/edge_velocity.h
@@ -253,9 +253,15 @@ public:
     double omega = g2o::normalize_theta(conf2->theta() - conf1->theta()) / deltaT->estimate();
 
     double max_vel_linear = std::max(std::max(cfg_->robot.max_vel_x, cfg_->robot.max_vel_y), cfg_->robot.max_vel_linear);
-    // double max_linear_vel_left = std::sqrt(max_vel_linear * max_vel_linear - vx * vx); // L2
-    double max_linear_vel_left = max_vel_linear - std::abs(vx); // L1
-    double max_vel_y = std::min(max_linear_vel_left, cfg_->robot.max_vel_y);
+
+    double max_linear_vel_remaining;
+    if (cfg_->optim.norm_vel_lin == 1) {
+      max_linear_vel_remaining = max_vel_linear - std::abs(vx);  // L1 norm
+    }
+    else {
+      max_linear_vel_remaining = std::sqrt(max_vel_linear * max_vel_linear - vx * vx); // L2 norm
+    }
+    double max_vel_y = std::min(max_linear_vel_remaining, cfg_->robot.max_vel_y);
 
     _error[0] = penaltyBoundToInterval(vx, -cfg_->robot.max_vel_x_backwards, cfg_->robot.max_vel_x, cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(vy, max_vel_y, 0.0); // we do not apply the penalty epsilon here, since the velocity could be close to zero

--- a/include/teb_local_planner/g2o_types/edge_velocity.h
+++ b/include/teb_local_planner/g2o_types/edge_velocity.h
@@ -252,14 +252,13 @@ public:
     double vy = r_dy / deltaT->estimate();
     double omega = g2o::normalize_theta(conf2->theta() - conf1->theta()) / deltaT->estimate();
 
-    double max_vel_trans = std::max(std::max(cfg_->robot.max_vel_x, cfg_->robot.max_vel_y), cfg_->robot.max_vel_trans);
 
     double max_vel_trans_remaining;
     if (cfg_->optim.norm_vel_trans == 1) {
-      max_vel_trans_remaining = max_vel_trans - std::abs(vx);  // L1 norm
+      max_vel_trans_remaining = std::max(0.0, cfg_->robot.max_vel_trans - std::abs(vx));  // L1 norm
     }
     else {
-      max_vel_trans_remaining = std::sqrt(max_vel_trans * max_vel_trans - vx * vx); // L2 norm
+      max_vel_trans_remaining = std::sqrt(std::max(0.0, cfg_->robot.max_vel_trans * cfg_->robot.max_vel_trans - vx * vx)); // L2 norm
     }
     double max_vel_y = std::min(max_vel_trans_remaining, cfg_->robot.max_vel_y);
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -95,7 +95,7 @@ public:
     double max_vel_x; //!< Maximum translational velocity of the robot
     double max_vel_x_backwards; //!< Maximum translational velocity of the robot for driving backwards
     double max_vel_y; //!< Maximum strafing velocity of the robot (should be zero for non-holonomic robots!)
-    double max_vel_linear; //!< Maximum translational velocity of the robot for omni robots, which is different from max_vel_x
+    double max_vel_trans; //!< Maximum translational velocity of the robot for omni robots, which is different from max_vel_x
     double max_vel_theta; //!< Maximum angular velocity of the robot
     double acc_lim_x; //!< Maximum translational acceleration of the robot
     double acc_lim_y; //!< Maximum strafing acceleration of the robot
@@ -173,7 +173,7 @@ public:
 
     double weight_adapt_factor; //!< Some special weights (currently 'weight_obstacle') are repeatedly scaled by this factor in each outer TEB iteration (weight_new = weight_old*factor); Increasing weights iteratively instead of setting a huge value a-priori leads to better numerical conditions of the underlying optimization problem.
     double obstacle_cost_exponent; //!< Exponent for nonlinear obstacle cost (cost = linear_cost * obstacle_cost_exponent). Set to 1 to disable nonlinear cost (default)
-    double norm_vel_lin; //!< Norm constraint for translational velocity (1: L1, 2: L2)
+    double norm_vel_trans; //!< Norm constraint for translational velocity (1: L1, 2: L2)
   } optim; //!< Optimization related parameters
 
 
@@ -272,7 +272,7 @@ public:
     robot.max_vel_x = 0.4;
     robot.max_vel_x_backwards = 0.2;
     robot.max_vel_y = 0.0;
-    robot.max_vel_linear = 0.4;
+    robot.max_vel_trans = 0.4;
     robot.max_vel_theta = 0.3;
     robot.acc_lim_x = 0.5;
     robot.acc_lim_y = 0.5;
@@ -339,7 +339,7 @@ public:
 
     optim.weight_adapt_factor = 2.0;
     optim.obstacle_cost_exponent = 1.0;
-    optim.norm_vel_lin = 1;
+    optim.norm_vel_trans = 1;
 
     // Homotopy Class Planner
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -173,6 +173,7 @@ public:
 
     double weight_adapt_factor; //!< Some special weights (currently 'weight_obstacle') are repeatedly scaled by this factor in each outer TEB iteration (weight_new = weight_old*factor); Increasing weights iteratively instead of setting a huge value a-priori leads to better numerical conditions of the underlying optimization problem.
     double obstacle_cost_exponent; //!< Exponent for nonlinear obstacle cost (cost = linear_cost * obstacle_cost_exponent). Set to 1 to disable nonlinear cost (default)
+    double norm_vel_lin; //!< Norm constraint for translational velocity (1: L1, 2: L2)
   } optim; //!< Optimization related parameters
 
 
@@ -338,6 +339,7 @@ public:
 
     optim.weight_adapt_factor = 2.0;
     optim.obstacle_cost_exponent = 1.0;
+    optim.norm_vel_lin = 1;
 
     // Homotopy Class Planner
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -173,7 +173,6 @@ public:
 
     double weight_adapt_factor; //!< Some special weights (currently 'weight_obstacle') are repeatedly scaled by this factor in each outer TEB iteration (weight_new = weight_old*factor); Increasing weights iteratively instead of setting a huge value a-priori leads to better numerical conditions of the underlying optimization problem.
     double obstacle_cost_exponent; //!< Exponent for nonlinear obstacle cost (cost = linear_cost * obstacle_cost_exponent). Set to 1 to disable nonlinear cost (default)
-    double norm_vel_trans; //!< Norm constraint for translational velocity (1: L1, 2: L2)
   } optim; //!< Optimization related parameters
 
 
@@ -339,7 +338,6 @@ public:
 
     optim.weight_adapt_factor = 2.0;
     optim.obstacle_cost_exponent = 1.0;
-    optim.norm_vel_trans = 1;
 
     // Homotopy Class Planner
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -105,6 +105,7 @@ public:
     bool is_footprint_dynamic; //<! If true, updated the footprint before checking trajectory feasibility
     bool use_proportional_saturation; //<! If true, reduce all twists components (linear x and y, and angular z) proportionally if any exceed its corresponding bounds, instead of saturating each one individually
     double transform_tolerance = 0.5; //<! Tolerance when querying the TF Tree for a transformation (seconds)
+    double max_vel_linear; //!< Maximum translational velocity of the robot for omni robots, which is different from max_vel_x
   } robot; //!< Robot related parameters
 
   //! Goal tolerance related parameters
@@ -279,6 +280,7 @@ public:
     robot.cmd_angle_instead_rotvel = false;
     robot.is_footprint_dynamic = false;
     robot.use_proportional_saturation = false;
+    robot.max_vel_linear = robot.max_vel_x;
 
     // GoalTolerance
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -272,6 +272,7 @@ public:
     robot.max_vel_x = 0.4;
     robot.max_vel_x_backwards = 0.2;
     robot.max_vel_y = 0.0;
+    robot.max_vel_linear = 0.4;
     robot.max_vel_theta = 0.3;
     robot.acc_lim_x = 0.5;
     robot.acc_lim_y = 0.5;
@@ -281,7 +282,6 @@ public:
     robot.cmd_angle_instead_rotvel = false;
     robot.is_footprint_dynamic = false;
     robot.use_proportional_saturation = false;
-    robot.max_vel_linear = robot.max_vel_x;
 
     // GoalTolerance
 

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -95,6 +95,7 @@ public:
     double max_vel_x; //!< Maximum translational velocity of the robot
     double max_vel_x_backwards; //!< Maximum translational velocity of the robot for driving backwards
     double max_vel_y; //!< Maximum strafing velocity of the robot (should be zero for non-holonomic robots!)
+    double max_vel_linear; //!< Maximum translational velocity of the robot for omni robots, which is different from max_vel_x
     double max_vel_theta; //!< Maximum angular velocity of the robot
     double acc_lim_x; //!< Maximum translational acceleration of the robot
     double acc_lim_y; //!< Maximum strafing acceleration of the robot
@@ -105,7 +106,6 @@ public:
     bool is_footprint_dynamic; //<! If true, updated the footprint before checking trajectory feasibility
     bool use_proportional_saturation; //<! If true, reduce all twists components (linear x and y, and angular z) proportionally if any exceed its corresponding bounds, instead of saturating each one individually
     double transform_tolerance = 0.5; //<! Tolerance when querying the TF Tree for a transformation (seconds)
-    double max_vel_linear; //!< Maximum translational velocity of the robot for omni robots, which is different from max_vel_x
   } robot; //!< Robot related parameters
 
   //! Goal tolerance related parameters

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -354,9 +354,11 @@ protected:
    * @param max_vel_y Maximum strafing velocity (for holonomic robots)
    * @param max_vel_theta Maximum (absolute) angular velocity
    * @param max_vel_x_backwards Maximum translational velocity for backwards driving
+   * @param max_vel_linear Maximum translational velocity holonomic robots
    */
   void saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y,
-                        double max_vel_theta, double max_vel_x_backwards) const;
+                        double max_vel_theta, double max_vel_x_backwards, 
+                        double max_vel_linear) const;
 
   
   /**

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -352,12 +352,12 @@ protected:
    * @param[in,out] omega The angular velocity that should be saturated.
    * @param max_vel_x Maximum translational velocity for forward driving
    * @param max_vel_y Maximum strafing velocity (for holonomic robots)
-   * @param max_vel_linear Maximum translational velocity for holonomic robots
+   * @param max_vel_trans Maximum translational velocity for holonomic robots
    * @param max_vel_theta Maximum (absolute) angular velocity
    * @param max_vel_x_backwards Maximum translational velocity for backwards driving
    */
   void saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y,
-                        double max_vel_linear, double max_vel_theta, double max_vel_x_backwards) const;
+                        double max_vel_trans, double max_vel_theta, double max_vel_x_backwards) const;
 
   
   /**

--- a/include/teb_local_planner/teb_local_planner_ros.h
+++ b/include/teb_local_planner/teb_local_planner_ros.h
@@ -352,13 +352,12 @@ protected:
    * @param[in,out] omega The angular velocity that should be saturated.
    * @param max_vel_x Maximum translational velocity for forward driving
    * @param max_vel_y Maximum strafing velocity (for holonomic robots)
+   * @param max_vel_linear Maximum translational velocity for holonomic robots
    * @param max_vel_theta Maximum (absolute) angular velocity
    * @param max_vel_x_backwards Maximum translational velocity for backwards driving
-   * @param max_vel_linear Maximum translational velocity holonomic robots
    */
   void saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y,
-                        double max_vel_theta, double max_vel_x_backwards, 
-                        double max_vel_linear) const;
+                        double max_vel_linear, double max_vel_theta, double max_vel_x_backwards) const;
 
   
   /**

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -137,6 +137,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("weight_prefer_rotdir", optim.weight_prefer_rotdir, optim.weight_prefer_rotdir);
   nh.param("weight_adapt_factor", optim.weight_adapt_factor, optim.weight_adapt_factor);
   nh.param("obstacle_cost_exponent", optim.obstacle_cost_exponent, optim.obstacle_cost_exponent);
+  nh.param("norm_vel_lin", optim.norm_vel_lin, optim.norm_vel_lin);
   
   // Homotopy Class Planner
   nh.param("enable_homotopy_class_planning", hcp.enable_homotopy_class_planning, hcp.enable_homotopy_class_planning); 
@@ -263,6 +264,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   optim.weight_viapoint = cfg.weight_viapoint;
   optim.weight_adapt_factor = cfg.weight_adapt_factor;
   optim.obstacle_cost_exponent = cfg.obstacle_cost_exponent;
+  optim.norm_vel_lin = cfg.norm_vel_lin;
   
   // Homotopy Class Planner
   hcp.enable_multithreading = cfg.enable_multithreading;

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -355,7 +355,7 @@ void TebConfig::checkParameters() const
 
   // holonomic check
   if (robot.max_vel_y > 0) {
-    if (robot.max_vel_trans < robot.max_vel_x || robot.max_vel_trans < robot.max_vel_y) {
+    if (robot.max_vel_trans < std::min(robot.max_vel_x, robot.max_vel_trans)) {
       ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_trans < max_vel_x or max_vel_trans < max_vel_y. Note that vel_trans = sqrt(Vx^2 + Vy^2), thus max_vel_trans will limit Vx and Vy in the optimization step.");
     }
     

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -356,9 +356,9 @@ void TebConfig::checkParameters() const
       ROS_WARN("TebLocalPlannerROS() Param Warning: parameter weight_optimaltime shoud be > 0 (even if weight_shortest_path is in use)");
 
   // holonomic check
-  if (robot.max_vel_y >= 0) {
+  if (robot.max_vel_y > 0) {
     if (robot.max_vel_linear < robot.max_vel_x || robot.max_vel_linear < robot.max_vel_y) {
-      ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_linear < max_vel_x or max_vel_linear < max_vel_y. Assuming max(max_vel_x, max_vel_y)");
+      ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_linear < max_vel_x or max_vel_linear < max_vel_y.");
     }
   }
   

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -74,7 +74,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("max_vel_x", robot.max_vel_x, robot.max_vel_x);
   nh.param("max_vel_x_backwards", robot.max_vel_x_backwards, robot.max_vel_x_backwards);
   nh.param("max_vel_y", robot.max_vel_y, robot.max_vel_y);
-  nh.param("max_vel_linear", robot.max_vel_linear, robot.max_vel_linear);
+  nh.param("max_vel_trans", robot.max_vel_trans, robot.max_vel_trans);
   nh.param("max_vel_theta", robot.max_vel_theta, robot.max_vel_theta);
   nh.param("acc_lim_x", robot.acc_lim_x, robot.acc_lim_x);
   nh.param("acc_lim_y", robot.acc_lim_y, robot.acc_lim_y);
@@ -137,7 +137,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("weight_prefer_rotdir", optim.weight_prefer_rotdir, optim.weight_prefer_rotdir);
   nh.param("weight_adapt_factor", optim.weight_adapt_factor, optim.weight_adapt_factor);
   nh.param("obstacle_cost_exponent", optim.obstacle_cost_exponent, optim.obstacle_cost_exponent);
-  nh.param("norm_vel_lin", optim.norm_vel_lin, optim.norm_vel_lin);
+  nh.param("norm_vel_trans", optim.norm_vel_trans, optim.norm_vel_trans);
   
   // Homotopy Class Planner
   nh.param("enable_homotopy_class_planning", hcp.enable_homotopy_class_planning, hcp.enable_homotopy_class_planning); 
@@ -215,7 +215,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   robot.wheelbase = cfg.wheelbase;
   robot.cmd_angle_instead_rotvel = cfg.cmd_angle_instead_rotvel;
   robot.use_proportional_saturation = cfg.use_proportional_saturation;
-  robot.max_vel_linear = cfg.max_vel_linear;
+  robot.max_vel_trans = cfg.max_vel_trans;
   
   // GoalTolerance
   goal_tolerance.xy_goal_tolerance = cfg.xy_goal_tolerance;
@@ -264,7 +264,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   optim.weight_viapoint = cfg.weight_viapoint;
   optim.weight_adapt_factor = cfg.weight_adapt_factor;
   optim.obstacle_cost_exponent = cfg.obstacle_cost_exponent;
-  optim.norm_vel_lin = cfg.norm_vel_lin;
+  optim.norm_vel_trans = cfg.norm_vel_trans;
   
   // Homotopy Class Planner
   hcp.enable_multithreading = cfg.enable_multithreading;
@@ -357,8 +357,8 @@ void TebConfig::checkParameters() const
 
   // holonomic check
   if (robot.max_vel_y > 0) {
-    if (robot.max_vel_linear < robot.max_vel_x || robot.max_vel_linear < robot.max_vel_y) {
-      ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_linear < max_vel_x or max_vel_linear < max_vel_y.");
+    if (robot.max_vel_trans < robot.max_vel_x || robot.max_vel_trans < robot.max_vel_y) {
+      ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_trans < max_vel_x or max_vel_trans < max_vel_y.");
     }
   }
   

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -74,6 +74,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("max_vel_x", robot.max_vel_x, robot.max_vel_x);
   nh.param("max_vel_x_backwards", robot.max_vel_x_backwards, robot.max_vel_x_backwards);
   nh.param("max_vel_y", robot.max_vel_y, robot.max_vel_y);
+  nh.param("max_vel_linear", robot.max_vel_linear, robot.max_vel_linear);
   nh.param("max_vel_theta", robot.max_vel_theta, robot.max_vel_theta);
   nh.param("acc_lim_x", robot.acc_lim_x, robot.acc_lim_x);
   nh.param("acc_lim_y", robot.acc_lim_y, robot.acc_lim_y);
@@ -84,7 +85,6 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("is_footprint_dynamic", robot.is_footprint_dynamic, robot.is_footprint_dynamic);
   nh.param("use_proportional_saturation", robot.use_proportional_saturation, robot.use_proportional_saturation);
   nh.param("transform_tolerance", robot.transform_tolerance, robot.transform_tolerance);
-  nh.param("max_vel_linear", robot.max_vel_linear, robot.max_vel_linear);
 
   // GoalTolerance
   nh.param("xy_goal_tolerance", goal_tolerance.xy_goal_tolerance, goal_tolerance.xy_goal_tolerance);

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -137,7 +137,6 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("weight_prefer_rotdir", optim.weight_prefer_rotdir, optim.weight_prefer_rotdir);
   nh.param("weight_adapt_factor", optim.weight_adapt_factor, optim.weight_adapt_factor);
   nh.param("obstacle_cost_exponent", optim.obstacle_cost_exponent, optim.obstacle_cost_exponent);
-  nh.param("norm_vel_trans", optim.norm_vel_trans, optim.norm_vel_trans);
   
   // Homotopy Class Planner
   nh.param("enable_homotopy_class_planning", hcp.enable_homotopy_class_planning, hcp.enable_homotopy_class_planning); 
@@ -264,7 +263,6 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   optim.weight_viapoint = cfg.weight_viapoint;
   optim.weight_adapt_factor = cfg.weight_adapt_factor;
   optim.obstacle_cost_exponent = cfg.obstacle_cost_exponent;
-  optim.norm_vel_trans = cfg.norm_vel_trans;
   
   // Homotopy Class Planner
   hcp.enable_multithreading = cfg.enable_multithreading;

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -356,7 +356,7 @@ void TebConfig::checkParameters() const
   // holonomic check
   if (robot.max_vel_y > 0) {
     if (robot.max_vel_trans < std::min(robot.max_vel_x, robot.max_vel_trans)) {
-      ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_trans < max_vel_x or max_vel_trans < max_vel_y. Note that vel_trans = sqrt(Vx^2 + Vy^2), thus max_vel_trans will limit Vx and Vy in the optimization step.");
+      ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_trans < min(max_vel_x, max_vel_y). Note that vel_trans = sqrt(Vx^2 + Vy^2), thus max_vel_trans will limit Vx and Vy in the optimization step.");
     }
     
     if (robot.max_vel_trans > std::max(robot.max_vel_x, robot.max_vel_y)) {

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -356,7 +356,11 @@ void TebConfig::checkParameters() const
   // holonomic check
   if (robot.max_vel_y > 0) {
     if (robot.max_vel_trans < robot.max_vel_x || robot.max_vel_trans < robot.max_vel_y) {
-      ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_trans < max_vel_x or max_vel_trans < max_vel_y.");
+      ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_trans < max_vel_x or max_vel_trans < max_vel_y. Note that vel_trans = sqrt(Vx^2 + Vy^2), thus max_vel_trans will limit Vx and Vy in the optimization step.");
+    }
+    
+    if (robot.max_vel_trans > std::max(robot.max_vel_x, robot.max_vel_y)) {
+      ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_trans > max(max_vel_x, max_vel_y). Robot will rotate and move diagonally to achieve max resultant vel (possibly max vel on both axis), limited by the max_vel_trans.");
     }
   }
   

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -84,6 +84,7 @@ void TebConfig::loadRosParamFromNodeHandle(const ros::NodeHandle& nh)
   nh.param("is_footprint_dynamic", robot.is_footprint_dynamic, robot.is_footprint_dynamic);
   nh.param("use_proportional_saturation", robot.use_proportional_saturation, robot.use_proportional_saturation);
   nh.param("transform_tolerance", robot.transform_tolerance, robot.transform_tolerance);
+  nh.param("max_vel_linear", robot.max_vel_linear, robot.max_vel_linear);
 
   // GoalTolerance
   nh.param("xy_goal_tolerance", goal_tolerance.xy_goal_tolerance, goal_tolerance.xy_goal_tolerance);
@@ -213,6 +214,7 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   robot.wheelbase = cfg.wheelbase;
   robot.cmd_angle_instead_rotvel = cfg.cmd_angle_instead_rotvel;
   robot.use_proportional_saturation = cfg.use_proportional_saturation;
+  robot.max_vel_linear = cfg.max_vel_linear;
   
   // GoalTolerance
   goal_tolerance.xy_goal_tolerance = cfg.xy_goal_tolerance;
@@ -350,6 +352,13 @@ void TebConfig::checkParameters() const
   // weights
   if (optim.weight_optimaltime <= 0)
       ROS_WARN("TebLocalPlannerROS() Param Warning: parameter weight_optimaltime shoud be > 0 (even if weight_shortest_path is in use)");
+
+  // holonomic check
+  if (robot.max_vel_y >= 0) {
+    if (robot.max_vel_linear < robot.max_vel_x || robot.max_vel_linear < robot.max_vel_y) {
+      ROS_WARN("TebLocalPlannerROS() Param Warning: max_vel_linear < max_vel_x or max_vel_linear < max_vel_y. Assuming max(max_vel_x, max_vel_y)");
+    }
+  }
   
 }    
 

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -421,8 +421,8 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   
   // Saturate velocity, if the optimization results violates the constraints (could be possible due to soft constraints).
   saturateVelocity(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z,
-                   cfg_.robot.max_vel_x, cfg_.robot.max_vel_y, cfg_.robot.max_vel_theta, cfg_.robot.max_vel_x_backwards, 
-                   cfg_.robot.max_vel_linear );
+                   cfg_.robot.max_vel_x, cfg_.robot.max_vel_y, cfg_.robot.max_vel_linear, cfg_.robot.max_vel_theta, 
+                   cfg_.robot.max_vel_x_backwards);
 
   // convert rot-vel to steering angle if desired (carlike robot).
   // The min_turning_radius is allowed to be slighly smaller since it is a soft-constraint
@@ -868,8 +868,8 @@ double TebLocalPlannerROS::estimateLocalGoalOrientation(const std::vector<geomet
 }
       
       
-void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y, double max_vel_theta, double max_vel_x_backwards, 
-                double max_vel_linear) const
+void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y, double max_vel_linear, double max_vel_theta, 
+              double max_vel_x_backwards) const
 {
   double ratio_x = 1, ratio_omega = 1, ratio_y = 1;
   // Limit translational velocity for forward driving

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -906,9 +906,8 @@ void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega,
     omega *= ratio_omega;
   }
 
-  max_vel_linear = std::max(std::max(max_vel_x, max_vel_y), max_vel_linear);
-  double vel_linear = std::sqrt(vx*vx + vy*vy);
-  if (vel_linear > std::abs(max_vel_linear))
+  double vel_linear = std::hypot(vx, vy);
+  if (vel_linear > max_vel_linear)
   {
     double max_vel_linear_ratio = max_vel_linear / vel_linear;
     vx *= max_vel_linear_ratio;

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -421,7 +421,8 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   
   // Saturate velocity, if the optimization results violates the constraints (could be possible due to soft constraints).
   saturateVelocity(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z,
-                   cfg_.robot.max_vel_x, cfg_.robot.max_vel_y, cfg_.robot.max_vel_theta, cfg_.robot.max_vel_x_backwards);
+                   cfg_.robot.max_vel_x, cfg_.robot.max_vel_y, cfg_.robot.max_vel_theta, cfg_.robot.max_vel_x_backwards, 
+                   cfg_.robot.max_vel_linear );
 
   // convert rot-vel to steering angle if desired (carlike robot).
   // The min_turning_radius is allowed to be slighly smaller since it is a soft-constraint
@@ -867,7 +868,8 @@ double TebLocalPlannerROS::estimateLocalGoalOrientation(const std::vector<geomet
 }
       
       
-void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y, double max_vel_theta, double max_vel_x_backwards) const
+void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y, double max_vel_theta, double max_vel_x_backwards, 
+                double max_vel_linear) const
 {
   double ratio_x = 1, ratio_omega = 1, ratio_y = 1;
   // Limit translational velocity for forward driving
@@ -902,6 +904,15 @@ void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega,
     vx *= ratio_x;
     vy *= ratio_y;
     omega *= ratio_omega;
+  }
+
+  max_vel_linear = std::max(std::max(max_vel_x, max_vel_y), max_vel_linear);
+  double vel_linear = std::sqrt(vx*vx + vy*vy);
+  if (vel_linear > std::abs(max_vel_linear))
+  {
+    double max_vel_linear_ratio = max_vel_linear / vel_linear;
+    vx *= max_vel_linear_ratio;
+    vy *= max_vel_linear_ratio;
   }
 }
      

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -421,7 +421,7 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   
   // Saturate velocity, if the optimization results violates the constraints (could be possible due to soft constraints).
   saturateVelocity(cmd_vel.twist.linear.x, cmd_vel.twist.linear.y, cmd_vel.twist.angular.z,
-                   cfg_.robot.max_vel_x, cfg_.robot.max_vel_y, cfg_.robot.max_vel_linear, cfg_.robot.max_vel_theta, 
+                   cfg_.robot.max_vel_x, cfg_.robot.max_vel_y, cfg_.robot.max_vel_trans, cfg_.robot.max_vel_theta, 
                    cfg_.robot.max_vel_x_backwards);
 
   // convert rot-vel to steering angle if desired (carlike robot).
@@ -868,7 +868,7 @@ double TebLocalPlannerROS::estimateLocalGoalOrientation(const std::vector<geomet
 }
       
       
-void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y, double max_vel_linear, double max_vel_theta, 
+void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega, double max_vel_x, double max_vel_y, double max_vel_trans, double max_vel_theta, 
               double max_vel_x_backwards) const
 {
   double ratio_x = 1, ratio_omega = 1, ratio_y = 1;
@@ -907,11 +907,11 @@ void TebLocalPlannerROS::saturateVelocity(double& vx, double& vy, double& omega,
   }
 
   double vel_linear = std::hypot(vx, vy);
-  if (vel_linear > max_vel_linear)
+  if (vel_linear > max_vel_trans)
   {
-    double max_vel_linear_ratio = max_vel_linear / vel_linear;
-    vx *= max_vel_linear_ratio;
-    vy *= max_vel_linear_ratio;
+    double max_vel_trans_ratio = max_vel_trans / vel_linear;
+    vx *= max_vel_trans_ratio;
+    vy *= max_vel_trans_ratio;
   }
 }
      


### PR DESCRIPTION
# Problem Description 
When we use holonomic robots, we should limit the maximum linear velocity (L-inf, L-1 or L-2 norm), not only `max_vel_x` and `max_vel_y`, because they are coupled.

Otherwise, the optimization for `vx` and `vy` results in `max_vel_x` and `max_vel_y` in open / collision-free paths. The robot will always move diagonally because the resultant (linear velocity) is greater. However, the maximum velocity is coupled and bounded to the actual maximum linear velocity of the robot. This new constraint should be added to the optimizer.

The video below shows the robot moving diagonally and it fixes the orientation at the end:

https://user-images.githubusercontent.com/6097267/148993227-5773c195-a3c6-4ad6-ab5a-503c104d751b.mp4

And one can see that the behaviour of the robot is not what we expect for a holonomic robot (changing  orientation a lot, and moving diagonally):

https://user-images.githubusercontent.com/6097267/148996957-d1a8698e-b858-4eb1-b1a5-319d458dc292.mp4

# Solution
Add `max_vel_linear` for holonomic robots and add the constraint to the optimization.

Long path not moving diagonally:

https://user-images.githubusercontent.com/6097267/148996627-7f598de7-23f8-4c17-818f-28df3a3e92f6.mp4


Moving around:

https://user-images.githubusercontent.com/6097267/148996037-e0d0d8df-6e35-4735-b835-095ed0cad98f.mp4


