### PR TITLE
[fix] only limit with max_vel_trans for holonomic vehicles

### DIFF
--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -89,7 +89,7 @@ grp_viapoints.add("via_points_ordered",   bool_t,   0,
 grp_robot = gen.add_group("Robot", type="tab")
 
 grp_robot.add("max_vel_x", double_t, 0, 
-	"Maximum translational velocity of the robot",
+	"Maximum translational velocity of the robot. May be overruled by the max_vel_trans parameter",
 	0.4, 0.01, 100)   
 
 grp_robot.add("max_vel_x_backwards", double_t, 0, 
@@ -140,11 +140,11 @@ grp_robot_carlike.add("cmd_angle_instead_rotvel",   bool_t,   0,
 grp_robot_omni = grp_robot.add_group("Omnidirectional", type="hide")
 
 grp_robot_omni.add("max_vel_y", double_t, 0, 
-  "Maximum strafing velocity of the robot (should be zero for non-holonomic robots!)",
+  "Maximum strafing velocity of the robot (should be zero for non-holonomic robots!). May be overruled by the max_vel_trans parameter",
   0.0, 0.0, 100)
 
 grp_robot_omni.add("max_vel_trans", double_t, 0, 
-  "Maximum linear velocity of the robot. Ignore this parameter for non-holonomic robots (max_vel_trans == max_vel_x).",
+  "Maximum linear velocity of the robot. Will limit max_vel_x and max_vel_y when their linear combination exceeds its value",
   0.4, 0.01, 100)
 
 grp_robot_omni.add("acc_lim_y", double_t, 0, 

--- a/cfg/TebLocalPlannerReconfigure.cfg
+++ b/cfg/TebLocalPlannerReconfigure.cfg
@@ -89,7 +89,7 @@ grp_viapoints.add("via_points_ordered",   bool_t,   0,
 grp_robot = gen.add_group("Robot", type="tab")
 
 grp_robot.add("max_vel_x", double_t, 0, 
-	"Maximum translational velocity of the robot. May be overruled by the max_vel_trans parameter",
+	"Maximum velocity in the x direction of the robot. May be overruled by the max_vel_trans parameter",
 	0.4, 0.01, 100)   
 
 grp_robot.add("max_vel_x_backwards", double_t, 0, 
@@ -144,8 +144,8 @@ grp_robot_omni.add("max_vel_y", double_t, 0,
   0.0, 0.0, 100)
 
 grp_robot_omni.add("max_vel_trans", double_t, 0, 
-  "Maximum linear velocity of the robot. Will limit max_vel_x and max_vel_y when their linear combination exceeds its value",
-  0.4, 0.01, 100)
+  "Maximum linear velocity of the robot. Will limit max_vel_x and max_vel_y when their linear combination exceeds its value. When set to default 0.0, it will be set equal to max_vel_x.",
+  0.0, 0.0, 100)
 
 grp_robot_omni.add("acc_lim_y", double_t, 0, 
   "Maximum strafing acceleration of the robot",

--- a/include/teb_local_planner/teb_config.h
+++ b/include/teb_local_planner/teb_config.h
@@ -271,7 +271,7 @@ public:
     robot.max_vel_x = 0.4;
     robot.max_vel_x_backwards = 0.2;
     robot.max_vel_y = 0.0;
-    robot.max_vel_trans = 0.4;
+    robot.max_vel_trans = 0.0;
     robot.max_vel_theta = 0.3;
     robot.acc_lim_x = 0.5;
     robot.acc_lim_y = 0.5;

--- a/src/teb_config.cpp
+++ b/src/teb_config.cpp
@@ -214,6 +214,11 @@ void TebConfig::reconfigure(TebLocalPlannerReconfigureConfig& cfg)
   robot.wheelbase = cfg.wheelbase;
   robot.cmd_angle_instead_rotvel = cfg.cmd_angle_instead_rotvel;
   robot.use_proportional_saturation = cfg.use_proportional_saturation;
+  if (cfg.max_vel_trans == 0.0)
+  {
+    ROS_INFO_STREAM("max_vel_trans is not set, setting it equal to max_vel_x: " << robot.max_vel_x);
+    cfg.max_vel_trans = robot.max_vel_x;
+  }
   robot.max_vel_trans = cfg.max_vel_trans;
   
   // GoalTolerance


### PR DESCRIPTION
a new parameter `max_vel_trans` was added in commit [f737130](https://github.com/rst-tu-dortmund/teb_local_planner/commit/f737130fa6a9024fef9fcdca6eadacaa69bf30a4) 

According to the documentation it should not affect for non-holonomic robots. But this was not implemented, and my robots vel_x was limited nevertheless.
`Maximum linear velocity of the robot. Ignore this parameter for non-holonomic robots (max_vel_trans == max_vel_x).`