### PR TITLE
More accurate visualization of obstacles

### DIFF
--- a/include/teb_local_planner/visualization.h
+++ b/include/teb_local_planner/visualization.h
@@ -151,8 +151,9 @@ public:
    * @brief Publish obstacle positions to the ros topic \e ../../teb_markers
    * @todo Move filling of the marker message to polygon class in order to avoid checking types.
    * @param obstacles Obstacle container
+   * @param scale Size of the non-circular obstacles
    */
-  void publishObstacles(const ObstContainer& obstacles) const;
+  void publishObstacles(const ObstContainer& obstacles, double scale = 0.1) const;
 
   /**
    * @brief Publish via-points to the ros topic \e ../../teb_markers

--- a/src/teb_local_planner_ros.cpp
+++ b/src/teb_local_planner_ros.cpp
@@ -452,7 +452,7 @@ uint32_t TebLocalPlannerROS::computeVelocityCommands(const geometry_msgs::PoseSt
   
   // Now visualize everything    
   planner_->visualize();
-  visualization_->publishObstacles(obstacles_);
+  visualization_->publishObstacles(obstacles_, costmap_->getResolution());
   visualization_->publishViaPoints(via_points_);
   visualization_->publishGlobalPlan(global_plan_);
   return mbf_msgs::ExePathResult::SUCCESS;

--- a/src/visualization.cpp
+++ b/src/visualization.cpp
@@ -150,7 +150,7 @@ void TebVisualization::publishInfeasibleRobotPose(const PoseSE2& current_pose, c
 }
 
 
-void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
+void TebVisualization::publishObstacles(const ObstContainer& obstacles, double scale) const
 {
   if ( obstacles.empty() || printErrorWhenNotInitialized() )
     return;
@@ -200,8 +200,8 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
       }
     }
     
-    marker.scale.x = 0.1;
-    marker.scale.y = 0.1;
+    marker.scale.x = scale;
+    marker.scale.y = scale;
     marker.color.a = 1.0;
     marker.color.r = 1.0;
     marker.color.g = 0.0;
@@ -272,8 +272,8 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
       end.z = 0;
       marker.points.push_back(end);
   
-      marker.scale.x = 0.1;
-      marker.scale.y = 0.1;
+      marker.scale.x = scale;
+      marker.scale.y = scale;
       marker.color.a = 1.0;
       marker.color.r = 0.0;
       marker.color.g = 1.0;
@@ -321,8 +321,8 @@ void TebVisualization::publishObstacles(const ObstContainer& obstacles) const
         point.z = 0;
         marker.points.push_back(point);
       }
-      marker.scale.x = 0.1;
-      marker.scale.y = 0.1;
+      marker.scale.x = scale;
+      marker.scale.y = scale;
       marker.color.a = 1.0;
       marker.color.r = 1.0;
       marker.color.g = 0.0;


### PR DESCRIPTION
Obstacle markers had a fixed size of 10cm, but this means that if the costmap has a low resolution and the robot is navigating close to obstacles, in rviz it will seem like the robot is in collision even though it isn't.

This PR changes it so that the obstacles have the same size as the costmap resolution.
This should provide a much more accurate visualization of the actual obstacle size!