### PR TITLE
Show also the actual footprint at infeasible poses

### DIFF
--- a/include/teb_local_planner/visualization.h
+++ b/include/teb_local_planner/visualization.h
@@ -139,14 +139,19 @@ public:
   void publishRobotFootprintModel(const PoseSE2& current_pose, const BaseRobotFootprintModel& robot_model, const std::string& ns = "RobotFootprintModel",
                                   const std_msgs::ColorRGBA& color = toColorMsg(0.5, 0.0, 0.8, 0.0));
 
+  void publishRobotFootprint(const PoseSE2& current_pose, const std::vector<geometry_msgs::Point>& footprint,
+                             const std::string& ns, const std_msgs::ColorRGBA &color);
+
   /**
-   * @brief Publish the robot footprints related to infeasible poses
+   * @brief Publish the robot footprint model and the actual robot footprint at an infeasible pose
    *
-   * @param current_pose Current pose of the robot
+   * @param infeasible_pose Infeasible pose to visualize
    * @param robot_model Subclass of BaseRobotFootprintModel
+   * @param footprint Actual robot footprint
    */
-  void publishInfeasibleRobotPose(const PoseSE2& current_pose, const BaseRobotFootprintModel& robot_model);
-  
+  void publishInfeasibleRobotPose(const PoseSE2& infeasible_pose, const BaseRobotFootprintModel& robot_model,
+                                  const std::vector<geometry_msgs::Point>& footprint);
+
   /**
    * @brief Publish obstacle positions to the ros topic \e ../../teb_markers
    * @todo Move filling of the marker message to polygon class in order to avoid checking types.

--- a/src/optimal_planner.cpp
+++ b/src/optimal_planner.cpp
@@ -1275,7 +1275,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
     {
       if (visualization_)
       {
-        visualization_->publishInfeasibleRobotPose(teb().Pose(i), *robot_model_);
+        visualization_->publishInfeasibleRobotPose(teb().Pose(i), *robot_model_, footprint_spec);
       }
       return false;
     }
@@ -1302,7 +1302,7 @@ bool TebOptimalPlanner::isTrajectoryFeasible(base_local_planner::CostmapModel* c
           {
             if (visualization_) 
             {
-              visualization_->publishInfeasibleRobotPose(intermediate_pose, *robot_model_);
+              visualization_->publishInfeasibleRobotPose(intermediate_pose, *robot_model_, footprint_spec);
             }
             return false;
           }


### PR DESCRIPTION
Useful to detect when the footprint model is not accurate enough
I chose not to use a parameter, as either visualization can be disabled by clicking the marker namespace, as shown in the video:
- red: footprint model (as before)
- orange: actual footprint

https://user-images.githubusercontent.com/322610/217402422-613ab552-db5b-4005-9b7c-f699f93ef6d4.mp4

