### PR TITLE
Add missing boost math libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ message(STATUS "System: ${CMAKE_SYSTEM}")
 ## System dependencies are found with CMake's conventions
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake_modules)
 message(STATUS "${CMAKE_MODULE_PATH}")
-find_package(Boost REQUIRED COMPONENTS system thread graph)
+find_package(Boost REQUIRED COMPONENTS system thread graph math)
 find_package(SUITESPARSE REQUIRED)
 find_package(G2O REQUIRED)
 
@@ -48,7 +48,7 @@ elseif (EXISTS "FindEigen.cmake")
 endif (EXISTS "FindEigen3.cmake")
 
 set(EXTERNAL_INCLUDE_DIRS ${Eigen_INCLUDE_DIRS} ${SUITESPARSE_INCLUDE_DIRS} ${G2O_INCLUDE_DIR})
-set(EXTERNAL_LIBS ${SUITESPARSE_LIBRARIES} ${G2O_LIBRARIES})
+set(EXTERNAL_LIBS ${SUITESPARSE_LIBRARIES} ${G2O_LIBRARIES} ${Boost_LIBRARIES})
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed


### PR DESCRIPTION
Fixes:
```
ld: warning: -pie being ignored. It is only used when linking a main executable
[1799](https://github.com/RoboStack/ros-noetic/actions/runs/3983387398/jobs/6829151526#step:3:1800)
Undefined symbols for architecture x86_64:
[1800](https://github.com/RoboStack/ros-noetic/actions/runs/3983387398/jobs/6829151526#step:3:1801)
  "int boost::math::sign<double>(double const&)", referenced from:
[1801](https://github.com/RoboStack/ros-noetic/actions/runs/3983387398/jobs/6829151526#step:3:1802)
      teb_local_planner::HSignature3d::isEqual(teb_local_planner::EquivalenceClass const&) const in homotopy_class_planner.cpp.o
[1802](https://github.com/RoboStack/ros-noetic/actions/runs/3983387398/jobs/6829151526#step:3:1803)
      teb_local_planner::HSignature3d::isEqual(teb_local_planner::EquivalenceClass const&) const in graph_search.cpp.o
[1803](https://github.com/RoboStack/ros-noetic/actions/runs/3983387398/jobs/6829151526#step:3:1804)
ld: symbol(s) not found for architecture x86_64
[1804](https://github.com/RoboStack/ros-noetic/actions/runs/3983387398/jobs/6829151526#step:3:1805)
```