### PR TITLE
Apply penalty_epsilon to max_vel_y on EdgeVelocityHolonomic

### DIFF
--- a/include/teb_local_planner/g2o_types/edge_velocity.h
+++ b/include/teb_local_planner/g2o_types/edge_velocity.h
@@ -255,15 +255,15 @@ public:
 
     double max_vel_trans_remaining_y;
     double max_vel_trans_remaining_x;
-    max_vel_trans_remaining_y = std::sqrt(std::max(0.0, cfg_->robot.max_vel_trans * cfg_->robot.max_vel_trans - vx * vx)); 
-    max_vel_trans_remaining_x = std::sqrt(std::max(0.0, cfg_->robot.max_vel_trans * cfg_->robot.max_vel_trans - vy * vy)); 
+    max_vel_trans_remaining_y = std::sqrt(std::max(0.0, cfg_->robot.max_vel_trans * cfg_->robot.max_vel_trans - vx * vx));
+    max_vel_trans_remaining_x = std::sqrt(std::max(0.0, cfg_->robot.max_vel_trans * cfg_->robot.max_vel_trans - vy * vy));
 
     double max_vel_y = std::min(max_vel_trans_remaining_y, cfg_->robot.max_vel_y);
     double max_vel_x = std::min(max_vel_trans_remaining_x, cfg_->robot.max_vel_x);
     double max_vel_x_backwards = std::min(max_vel_trans_remaining_x, cfg_->robot.max_vel_x_backwards);
 
     _error[0] = penaltyBoundToInterval(vx, -max_vel_x_backwards, max_vel_x, cfg_->optim.penalty_epsilon);
-    _error[1] = penaltyBoundToInterval(vy, max_vel_y, 0.0); // we do not apply the penalty epsilon here, since the velocity could be close to zero
+    _error[1] = penaltyBoundToInterval(vy, max_vel_y, cfg_->optim.penalty_epsilon);
     _error[2] = penaltyBoundToInterval(omega, cfg_->robot.max_vel_theta,cfg_->optim.penalty_epsilon);
 
     ROS_ASSERT_MSG(std::isfinite(_error[0]) && std::isfinite(_error[1]) && std::isfinite(_error[2]),


### PR DESCRIPTION
This is more a question than a contribution. Why exactly we don't apply penalty_epsilon to max_vel_y?
The comment doesn't make much sense to me, as this is an holonomic edge and so we should not prioritize any orientation

Thanks in advance for any input! 