### PR TITLE
Fix #359: Remove penalty_epsilon from max_vel_x error calculation

### DIFF
--- a/include/teb_local_planner/g2o_types/edge_velocity.h
+++ b/include/teb_local_planner/g2o_types/edge_velocity.h
@@ -262,8 +262,10 @@ public:
     double max_vel_x = std::min(max_vel_trans_remaining_x, cfg_->robot.max_vel_x);
     double max_vel_x_backwards = std::min(max_vel_trans_remaining_x, cfg_->robot.max_vel_x_backwards);
 
-    _error[0] = penaltyBoundToInterval(vx, -max_vel_x_backwards, max_vel_x, cfg_->optim.penalty_epsilon);
-    _error[1] = penaltyBoundToInterval(vy, max_vel_y, 0.0); // we do not apply the penalty epsilon here, since the velocity could be close to zero
+    // we do not apply the penalty epsilon for linear velocities on
+    // holonomic robots, since either vx or yy could be close to zero
+    _error[0] = penaltyBoundToInterval(vx, -max_vel_x_backwards, max_vel_x, 0.0);
+    _error[1] = penaltyBoundToInterval(vy, max_vel_y, 0.0);
     _error[2] = penaltyBoundToInterval(omega, cfg_->robot.max_vel_theta,cfg_->optim.penalty_epsilon);
 
     ROS_ASSERT_MSG(std::isfinite(_error[0]) && std::isfinite(_error[1]) && std::isfinite(_error[2]),


### PR DESCRIPTION
Check issue #359 for a detailed description of the problem and PR #402 for a reproducing it

I'm not sure about how this solves the problem, but seems to work. I'll keep as a draft until I understand what's going on

**UPDATE:**  @RainerKuemmerle agrees that this change makes sense. He believes that what happens is that this epsilon affects the numeric evaluation of the gradient at some point.
Also we are using the change at Rapyuta w/o issues, so I change to ready for review