### PR TITLE
[ROS2] fix planning local path from single updated global path

### DIFF
--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -713,8 +713,8 @@ bool TebLocalPlannerROS::transformGlobalPlan(const std::vector<geometry_msgs::ms
 
     // get plan_to_global_transform from plan frame to global_frame
     geometry_msgs::msg::TransformStamped plan_to_global_transform = tf_->lookupTransform(
-                global_frame, tf2_ros::fromMsg(plan_pose.header.stamp),
-                plan_pose.header.frame_id, tf2::timeFromSec(0),
+                global_frame, tf2_ros::fromMsg(clock_->now()),
+                plan_pose.header.frame_id, tf2_ros::fromMsg(plan_pose.header.stamp),
                 plan_pose.header.frame_id, tf2::durationFromSec(0.5));
 
 //    tf_->waitForTransform(global_frame, ros::Time::now(),


### PR DESCRIPTION
ROS2 navigation stack has new behaviors which only update the global path based on time, distance or if it gets invalidated. This means that the path does not include new timestamps.

In `transformGlobalPlan` the lookup uses the timestamp of the path to get the target timestamp for the transform. This should be changed to the current time. This behavior is the same in other nav2 controllers.

To replicate the bug use any of the behaviour trees which do not update the global path, e.g. `navigate_w_replanning_only_if_goal_is_updated.xml`, and send a goal which takes some time to complete (+5s).