### PR TITLE
nlamprian/fix_duplicate_node

### DIFF
--- a/teb_local_planner/src/teb_local_planner_ros.cpp
+++ b/teb_local_planner/src/teb_local_planner_ros.cpp
@@ -85,10 +85,14 @@ void TebLocalPlannerROS::initialize(nav2_util::LifecycleNode::SharedPtr node)
   // check if the plugin is already initialized
   if(!initialized_)
   {	
+    auto options = rclcpp::NodeOptions().arguments(
+      {"--ros-args", "-r",
+       std::string("__node:=") + node->get_name() + "_" + name_ +
+           "_costmap_converter_rclcpp_node",
+       "--"});
+    intra_proc_node_ = std::make_shared<rclcpp::Node>("_", options);
+
     // declare parameters (ros2-dashing)
-    intra_proc_node_.reset( 
-            new rclcpp::Node("costmap_converter", node->get_namespace(), 
-              rclcpp::NodeOptions()));
     cfg_->declareParameters(node, name_);
 
     // get parameters of TebConfig via the nodehandle and override the default config


### PR DESCRIPTION
There is a duplicate node created for the costmap converter, as indicated by this warning.

```
[controller_server-15] [WARN] [rcl.logging_rosout]: Publisher already registered for provided node name. If this is due to multiple nodes with the same name then all logs for that logger name will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.
```

It can be verified with

```
$ ros2 node list | ag controller
WARNING: Be aware that are nodes in the graph that share an exact name, this can have unintended side effects.
/controller_server_node
/controller_server_node
```

With this change, it now gives

```
$ ros2 node list | ag controller
/controller_server_node
/controller_server_node_FollowPath_costmap_converter_rclcpp_node
```

Solution taken from the [navigation2](https://github.com/ros-planning/navigation2/blob/73072ae19bfa76c505685a4735ea278d3b499cbe/nav2_util/src/node_utils.cpp#L88).